### PR TITLE
Kotlin 1.4.0

### DIFF
--- a/.github/conf/gradle.ubuntu-latest
+++ b/.github/conf/gradle.ubuntu-latest
@@ -1,6 +1,6 @@
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m
 
-javah=/usr/lib/jvm/zulu-8-azure-amd64/bin/javah
+javah=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/bin/javah
 
 excludeTargets=android

--- a/.github/conf/gradle.universal
+++ b/.github/conf/gradle.universal
@@ -4,3 +4,4 @@ org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m
 javah=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/bin/javah
 
 excludeTargets=native
+android.useAndroidX=true

--- a/.github/conf/gradle.universal
+++ b/.github/conf/gradle.universal
@@ -1,6 +1,6 @@
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m
 
-javah=/usr/lib/jvm/zulu-8-azure-amd64/bin/javah
+javah=/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/bin/javah
 
 excludeTargets=native

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -48,14 +48,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
+      - name: Setup Android SDK dir
+        run: echo sdk.dir=$ANDROID_HOME > local.properties
+      - name: install default NDK for AGP
+        run: $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669"
+      - name: Setup gradle.properties
+        run: mv .github/conf/gradle.universal gradle.properties
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Setup Android SDK dir
-        run: echo sdk.dir=$ANDROID_HOME > local.properties
-      - name: Setup gradle.properties
-        run: mv .github/conf/gradle.universal gradle.properties
       - name: Check
         uses: eskatos/gradle-command-action@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,14 +51,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
+      - name: Setup Android SDK dir
+        run: echo sdk.dir=$ANDROID_HOME > local.properties
+      - name: install default NDK for AGP
+        run: $ANDROID_HOME/tools/bin/sdkmanager "ndk;21.0.6113669"
+      - name: Setup gradle.properties
+        run: mv .github/conf/gradle.universal gradle.properties
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Setup Android SDK dir
-        run: echo sdk.dir=$ANDROID_HOME > local.properties
-      - name: Setup gradle.properties
-        run: mv .github/conf/gradle.universal gradle.properties
       - name: Check
         uses: eskatos/gradle-command-action@v1
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,11 +2,10 @@ plugins {
     id("org.kodein.root")
 }
 
-val kotlinxAtomicFuVer by extra { "0.14.3-1.4.0-rc" } // CAUTION: also change in buildscript!
-val kotlinxSerializationVer by extra { "1.0-M1-1.4.0-rc" }
-//val kotlinxCoroutinesVer by extra { "1.3.3" }
-val kodeinLogVer by extra { "0.4.0-kotlin-1.4-rc-43" }
-val kodeinMemoryVer by extra { "0.2.0-kotlin-1.4-rc-35" }
+val kotlinxAtomicFuVer by extra { "0.14.4" } // CAUTION: also change in buildscript!
+val kotlinxSerializationVer by extra { "1.0.0-RC" }
+val kodeinLogVer by extra { "0.5.0" }
+val kodeinMemoryVer by extra { "0.3.0" }
 
 buildscript {
     repositories {
@@ -14,7 +13,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("org.jetbrains.kotlinx:atomicfu-gradle-plugin:0.14.3-1.4.0-rc")
+        classpath("org.jetbrains.kotlinx:atomicfu-gradle-plugin:0.14.4")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,13 +2,11 @@ plugins {
     id("org.kodein.root")
 }
 
-val kotlinxAtomicFuVer by extra { "0.14.2" } // CAUTION: also change in buildscript!
-val kotlinxSerializationVer by extra { "0.20.0" }
+val kotlinxAtomicFuVer by extra { "0.14.3-1.4.0-rc" } // CAUTION: also change in buildscript!
+val kotlinxSerializationVer by extra { "1.0-M1-1.4.0-rc" }
 //val kotlinxCoroutinesVer by extra { "1.3.3" }
-//val kodeinLogVer by extra { "0.2.0-dev-805458618" }
-//val kodeinMemoryVer by extra { "0.2.0-dev-806010368" }
-val kodeinLogVer by extra { "0.2.0-dev-17" }
-val kodeinMemoryVer by extra { "0.2.0-dev-26" }
+val kodeinLogVer by extra { "0.4.0-kotlin-1.4-rc-43" }
+val kodeinMemoryVer by extra { "0.2.0-kotlin-1.4-rc-35" }
 
 buildscript {
     repositories {
@@ -16,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("org.jetbrains.kotlinx:atomicfu-gradle-plugin:0.14.2")
+        classpath("org.jetbrains.kotlinx:atomicfu-gradle-plugin:0.14.3-1.4.0-rc")
     }
 }
 

--- a/kdb/kodein-db-api/build.gradle.kts
+++ b/kdb/kodein-db-api/build.gradle.kts
@@ -10,7 +10,7 @@ kodein {
 
         common.main.dependencies {
             api(project(":ldb:kodein-leveldb-api"))
-            implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinxSerializationVer")
+            implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVer")
         }
 
         add(kodeinTargets.jvm.jvm)

--- a/kdb/kodein-db-api/build.gradle.kts
+++ b/kdb/kodein-db-api/build.gradle.kts
@@ -10,20 +10,11 @@ kodein {
 
         common.main.dependencies {
             api(project(":ldb:kodein-leveldb-api"))
-            compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-runtime-common:$kotlinxSerializationVer")
+            implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinxSerializationVer")
         }
 
-        add(kodeinTargets.jvm.jvm) {
-            main.dependencies {
-                compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinxSerializationVer")
-            }
-        }
-
-        add(kodeinTargets.native.allApple + kodeinTargets.native.allDesktop) {
-            main.dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:$kotlinxSerializationVer")
-            }
-        }
+        add(kodeinTargets.jvm.jvm)
+        add(kodeinTargets.native.allDarwin + kodeinTargets.native.allDesktop)
     }
 }
 

--- a/kdb/kodein-db-api/src/allNativeMain/kotlin/org/kodein/db/simpleNameOf.kt
+++ b/kdb/kodein-db-api/src/allNativeMain/kotlin/org/kodein/db/simpleNameOf.kt
@@ -2,4 +2,4 @@ package org.kodein.db
 
 import kotlin.reflect.KClass
 
-actual fun simpleTypeNameOf(type: KClass<*>): String = type.simpleName ?: throw IllegalStateException("Could not find simple name of type")
+public actual fun simpleTypeNameOf(type: KClass<*>): String = type.simpleName ?: throw IllegalStateException("Could not find simple name of type")

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/BaseCursor.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/BaseCursor.kt
@@ -3,17 +3,17 @@ package org.kodein.db
 import org.kodein.memory.Closeable
 import org.kodein.memory.io.ReadMemory
 
-interface BaseCursor : Closeable {
+public interface BaseCursor : Closeable {
 
-    fun isValid(): Boolean
+    public fun isValid(): Boolean
 
-    fun next()
-    fun prev()
+    public fun next()
+    public fun prev()
 
-    fun seekToFirst()
-    fun seekToLast()
-    fun seekTo(target: ReadMemory)
+    public fun seekToFirst()
+    public fun seekToLast()
+    public fun seekTo(target: ReadMemory)
 
-    fun transientSeekKey(): ReadMemory
+    public fun transientSeekKey(): ReadMemory
 
 }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Batch.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Batch.kt
@@ -3,8 +3,8 @@ package org.kodein.db
 import org.kodein.memory.Closeable
 
 
-interface Batch : DBWrite, Closeable {
-    fun addOptions(vararg options: Options.Write)
-    fun Options.Write.unaryPlus() = addOptions(this)
-    fun write(vararg options: Options.Write)
+public interface Batch : DBWrite, Closeable {
+    public fun addOptions(vararg options: Options.Write)
+    public fun Options.Write.unaryPlus(): Unit = addOptions(this)
+    public fun write(vararg options: Options.Write)
 }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Body.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Body.kt
@@ -2,13 +2,13 @@ package org.kodein.db
 
 import org.kodein.memory.io.Writeable
 
-interface Body {
+public interface Body {
 
-    fun writeInto(dst: Writeable)
+    public fun writeInto(dst: Writeable)
 
-    companion object {
+    public companion object {
 
-        inline operator fun invoke(crossinline block: (Writeable) -> Unit) = object : Body {
+        public inline operator fun invoke(crossinline block: (Writeable) -> Unit): Body = object : Body {
             override fun writeInto(dst: Writeable) = block(dst)
         }
 

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Cursor.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Cursor.kt
@@ -2,16 +2,16 @@ package org.kodein.db
 
 import org.kodein.memory.use
 
-interface Cursor<M: Any> : BaseCursor {
+public interface Cursor<M: Any> : BaseCursor {
 
-    fun key(): Key<M>
-    fun model(vararg options: Options.Read): M
+    public fun key(): Key<M>
+    public fun model(vararg options: Options.Read): M
 
-    fun duplicate(): Cursor<M>
+    public fun duplicate(): Cursor<M>
 
 }
 
-fun <M : Any> Cursor<M>.models(): Sequence<M> = sequence {
+public fun <M : Any> Cursor<M>.models(): Sequence<M> = sequence {
     use {
         while (isValid()) {
             yield(model())
@@ -20,9 +20,9 @@ fun <M : Any> Cursor<M>.models(): Sequence<M> = sequence {
     }
 }
 
-data class Entry<M : Any>(val key: Key<M>, val model: M)
+public data class Entry<M : Any>(val key: Key<M>, val model: M)
 
-fun <M : Any> Cursor<M>.entries(): Sequence<Entry<M>> = sequence {
+public fun <M : Any> Cursor<M>.entries(): Sequence<Entry<M>> = sequence {
     use {
         while (isValid()) {
             yield(Entry(key(), model()))

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/DB.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/DB.kt
@@ -4,29 +4,29 @@ import org.kodein.memory.Closeable
 import org.kodein.memory.use
 import kotlin.reflect.KClass
 
-interface DB : DBRead, DBWrite, Closeable {
+public interface DB : DBRead, DBWrite, Closeable {
 
-    fun newBatch(): Batch
+    public fun newBatch(): Batch
 
-    fun newSnapshot(vararg options: Options.Read): Snapshot
+    public fun newSnapshot(vararg options: Options.Read): Snapshot
 
-    interface RegisterDsl<M : Any> {
-        fun filter(f: (M) -> Boolean): RegisterDsl<M>
-        fun register(listener: DBListener<M>): Closeable
-        fun register(builder: DBListener.Builder<M>.() -> Unit): Closeable
+    public interface RegisterDsl<M : Any> {
+        public fun filter(f: (M) -> Boolean): RegisterDsl<M>
+        public fun register(listener: DBListener<M>): Closeable
+        public fun register(builder: DBListener.Builder<M>.() -> Unit): Closeable
     }
 
-    fun onAll(): RegisterDsl<Any>
+    public fun onAll(): RegisterDsl<Any>
 
-    fun <M : Any> on(type: KClass<M>): RegisterDsl<M>
+    public fun <M : Any> on(type: KClass<M>): RegisterDsl<M>
 
-    companion object
+    public companion object
 }
 
-inline fun DB.execBatch(vararg options: Options.Write, block: Batch.() -> Unit) =
+public inline fun DB.execBatch(vararg options: Options.Write, block: Batch.() -> Unit): Unit =
         newBatch().use {
             it.block()
             it.write(*options)
         }
 
-inline fun <reified M : Any> DB.on() = on(M::class)
+public inline fun <reified M : Any> DB.on(): DB.RegisterDsl<M> = on(M::class)

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/DBFactory.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/DBFactory.kt
@@ -1,14 +1,14 @@
 package org.kodein.db
 
-interface DBFactory<T : Any> {
-    fun open(path: String, vararg options: Options.Open): T
-    fun destroy(path: String, vararg options: Options.Open)
+public interface DBFactory<T : Any> {
+    public fun open(path: String, vararg options: Options.Open): T
+    public fun destroy(path: String, vararg options: Options.Open)
 
-    class Based<T : Any> internal constructor(private val baseWithSeparator: String, private val factory: DBFactory<T>) : DBFactory<T> {
-        override fun open(path: String, vararg options: Options.Open) = factory.open(baseWithSeparator + path, *options)
-        override fun destroy(path: String, vararg options: Options.Open) = factory.destroy(baseWithSeparator + path, *options)
+    public class Based<T : Any> internal constructor(private val baseWithSeparator: String, private val factory: DBFactory<T>) : DBFactory<T> {
+        override fun open(path: String, vararg options: Options.Open): T = factory.open(baseWithSeparator + path, *options)
+        override fun destroy(path: String, vararg options: Options.Open): Unit = factory.destroy(baseWithSeparator + path, *options)
     }
 }
 
-fun <T : Any> DBFactory<T>.prefixed(prefix: String) = DBFactory.Based(prefix, this)
-fun <T : Any> DBFactory<T>.inDir(path: String) = prefixed("$path/")
+public fun <T : Any> DBFactory<T>.prefixed(prefix: String): DBFactory.Based<T> = DBFactory.Based(prefix, this)
+public fun <T : Any> DBFactory<T>.inDir(path: String): DBFactory.Based<T> = prefixed("$path/")

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/DBListener.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/DBListener.kt
@@ -4,26 +4,26 @@ import org.kodein.db.model.orm.Metadata
 import org.kodein.memory.Closeable
 import org.kodein.memory.io.ReadMemory
 
-interface DBListener<in M : Any> {
+public interface DBListener<in M : Any> {
 
-    fun setSubscription(subscription: Closeable) {}
+    public fun setSubscription(subscription: Closeable) {}
 
-    fun willPut(model: M, typeName: ReadMemory, metadata: Metadata, options: Array<out Options.Write>) {}
+    public fun willPut(model: M, typeName: ReadMemory, metadata: Metadata, options: Array<out Options.Write>) {}
 
-    fun didPut(model: M, key: Key<*>, typeName: ReadMemory, metadata: Metadata, size: Int, options: Array<out Options.Write>) {}
+    public fun didPut(model: M, key: Key<*>, typeName: ReadMemory, metadata: Metadata, size: Int, options: Array<out Options.Write>) {}
 
-    fun willDelete(key: Key<*>, getModel: () -> M?, typeName: ReadMemory, options: Array<out Options.Write>) {}
+    public fun willDelete(key: Key<*>, getModel: () -> M?, typeName: ReadMemory, options: Array<out Options.Write>) {}
 
-    fun didDelete(key: Key<*>, model: M?, typeName: ReadMemory, options: Array<out Options.Write>) {}
+    public fun didDelete(key: Key<*>, model: M?, typeName: ReadMemory, options: Array<out Options.Write>) {}
 
-    class Builder<M : Any> {
-        class WillPut(val typeName: ReadMemory, val options: Array<out Options.Write>, val subscription: Closeable)
+    public class Builder<M : Any> {
+        public class WillPut(public val typeName: ReadMemory, public val options: Array<out Options.Write>, public val subscription: Closeable)
 
-        class DidPut(val key: Key<*>, val typeName: ReadMemory, val options: Array<out Options.Write>, val subscription: Closeable)
+        public class DidPut(public val key: Key<*>, public val typeName: ReadMemory, public val options: Array<out Options.Write>, public val subscription: Closeable)
 
-        class WillDelete(val key: Key<*>, val typeName: ReadMemory, val options: Array<out Options.Write>, val subscription: Closeable)
+        public class WillDelete(public val key: Key<*>, public val typeName: ReadMemory, public val options: Array<out Options.Write>, public val subscription: Closeable)
 
-        class DidDelete(val key: Key<*>, val typeName: ReadMemory, val options: Array<out Options.Write>, val subscription: Closeable)
+        public class DidDelete(public val key: Key<*>, public val typeName: ReadMemory, public val options: Array<out Options.Write>, public val subscription: Closeable)
 
         private var willPut: (WillPut.(M) -> Unit)? = null
         private var didPut: (DidPut.(M) -> Unit)? = null
@@ -33,32 +33,32 @@ interface DBListener<in M : Any> {
 
         private var didDeleteNeedsModel = false
 
-        fun willPut(block: WillPut.(M) -> Unit) {
+        public fun willPut(block: WillPut.(M) -> Unit) {
             willPut = block
         }
 
-        fun didPut(block: DidPut.(M) -> Unit) {
+        public fun didPut(block: DidPut.(M) -> Unit) {
             didPut = block
         }
 
-        fun willDelete(block: WillDelete.() -> Unit) {
+        public fun willDelete(block: WillDelete.() -> Unit) {
             willDelete = { block() }
         }
 
-        fun willDeleteIt(block: WillDelete.(M) -> Unit) {
+        public fun willDeleteIt(block: WillDelete.(M) -> Unit) {
             willDelete = { it()?.let { block(it) } }
         }
 
-        fun didDelete(block: DidDelete.() -> Unit) {
+        public fun didDelete(block: DidDelete.() -> Unit) {
             didDelete = { block() }
         }
 
-        fun didDeleteIt(block: DidDelete.(M) -> Unit) {
+        public fun didDeleteIt(block: DidDelete.(M) -> Unit) {
             didDeleteNeedsModel = true
             didDelete = { it?.let { block(it) } }
         }
 
-        fun build() = object : DBListener<M> {
+        public fun build(): DBListener<M> = object : DBListener<M> {
             private lateinit var subscription: Closeable
 
             override fun setSubscription(subscription: Closeable) {

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/DBRead.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/DBRead.kt
@@ -4,26 +4,26 @@ package org.kodein.db
 
 import kotlin.reflect.KClass
 
-interface DBRead : KeyMaker {
+public interface DBRead : KeyMaker {
 
-    operator fun <M : Any> get(type: KClass<M>, key: Key<M>, vararg options: Options.Read): M?
+    public operator fun <M : Any> get(type: KClass<M>, key: Key<M>, vararg options: Options.Read): M?
 
-    fun findAll(vararg options: Options.Read): Cursor<*>
+    public fun findAll(vararg options: Options.Read): Cursor<*>
 
-    interface FindDsl<M : Any> {
+    public interface FindDsl<M : Any> {
 
-        fun all(): Cursor<M> = byId()
+        public fun all(): Cursor<M> = byId()
 
-        fun byId(vararg id: Any, isOpen: Boolean = false): Cursor<M>
+        public fun byId(vararg id: Any, isOpen: Boolean = false): Cursor<M>
 
-        fun byIndex(index: String, vararg value: Any, isOpen: Boolean = false): Cursor<M>
+        public fun byIndex(index: String, vararg value: Any, isOpen: Boolean = false): Cursor<M>
     }
 
-    fun <M : Any> find(type: KClass<M>, vararg options: Options.Read): FindDsl<M>
+    public fun <M : Any> find(type: KClass<M>, vararg options: Options.Read): FindDsl<M>
 
-    fun getIndexesOf(key: Key<*>, vararg options: Options.Read): Set<String>
+    public fun getIndexesOf(key: Key<*>, vararg options: Options.Read): Set<String>
 
 }
 
-inline operator fun <reified M : Any> DBRead.get(key: Key<M>, vararg options: Options.Read) = get(M::class, key, *options)
-inline fun <reified M : Any> DBRead.find(vararg options: Options.Read) = find(M::class, *options)
+public inline operator fun <reified M : Any> DBRead.get(key: Key<M>, vararg options: Options.Read): M? = get(M::class, key, *options)
+public inline fun <reified M : Any> DBRead.find(vararg options: Options.Read): DBRead.FindDsl<M> = find(M::class, *options)

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/DBWrite.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/DBWrite.kt
@@ -2,11 +2,11 @@ package org.kodein.db
 
 import kotlin.reflect.KClass
 
-interface DBWrite : KeyMaker {
-    fun <M : Any> put(model: M, vararg options: Options.Write): Key<M>
-    fun <M : Any> put(key: Key<M>, model: M, vararg options: Options.Write)
+public interface DBWrite : KeyMaker {
+    public fun <M : Any> put(model: M, vararg options: Options.Write): Key<M>
+    public fun <M : Any> put(key: Key<M>, model: M, vararg options: Options.Write)
 
-    fun <M : Any> delete(type: KClass<M>, key: Key<M>, vararg options: Options.Write)
+    public fun <M : Any> delete(type: KClass<M>, key: Key<M>, vararg options: Options.Write)
 }
 
-inline fun <reified M : Any> DBWrite.delete(key: Key<M>, vararg options: Options.Write) = delete(M::class, key, *options)
+public inline fun <reified M : Any> DBWrite.delete(key: Key<M>, vararg options: Options.Write): Unit = delete(M::class, key, *options)

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Index.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Index.kt
@@ -1,6 +1,6 @@
 package org.kodein.db
 
-data class Index(val name: String, val value: Any)
+public data class Index(val name: String, val value: Any)
 
-fun indexSet(vararg indexAndValues: Pair<String, Any>): Set<Index> =
+public fun indexSet(vararg indexAndValues: Pair<String, Any>): Set<Index> =
         indexAndValues.map { Index(it.first, it.second) } .toHashSet()

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Key.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Key.kt
@@ -1,6 +1,11 @@
 package org.kodein.db
 
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import org.kodein.memory.io.KBuffer
 import org.kodein.memory.io.ReadMemory
 import org.kodein.memory.io.markBuffer
@@ -9,21 +14,21 @@ import org.kodein.memory.text.Base64
 
 @Suppress("unused")
 @Serializable(with = Key.KeySerializer::class)
-data class Key<out T : Any>(val bytes: ReadMemory) {
+public data class Key<out T : Any>(val bytes: ReadMemory) {
 
-    class KeySerializer<T: Any>(@Suppress("UNUSED_PARAMETER") tSerializer: KSerializer<T>) : KSerializer<Key<T>> {
-        override val descriptor: SerialDescriptor = PrimitiveDescriptor("org.kodein.db.Key", PrimitiveKind.STRING)
+    public class KeySerializer<T: Any>(@Suppress("UNUSED_PARAMETER") tSerializer: KSerializer<T>) : KSerializer<Key<T>> {
+        override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("org.kodein.db.Key", PrimitiveKind.STRING)
 
-        override fun deserialize(decoder: Decoder): Key<T> = Key(KBuffer.wrap(b64Decoder.decode(decoder.decodeString())))
+        public override fun deserialize(decoder: Decoder): Key<T> = Key(KBuffer.wrap(b64Decoder.decode(decoder.decodeString())))
 
-        override fun serialize(encoder: Encoder, value: Key<T>) = encoder.encodeString(value.toBase64())
+        public override fun serialize(encoder: Encoder, value: Key<T>): Unit = encoder.encodeString(value.toBase64())
     }
 
-    fun toBase64(): String = bytes.markBuffer { b64Encoder.encode(it) }
+    public fun toBase64(): String = bytes.markBuffer { b64Encoder.encode(it) }
 
-    companion object {
-        val b64Encoder = Base64.encoder.withoutPadding()
-        val b64Decoder = Base64.decoder
+    public companion object {
+        public val b64Encoder: Base64.Encoder = Base64.encoder.withoutPadding()
+        public val b64Decoder: Base64.Decoder = Base64.decoder
     }
 
 }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/KeyMaker.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/KeyMaker.kt
@@ -2,14 +2,14 @@ package org.kodein.db
 
 import kotlin.reflect.KClass
 
-interface KeyMaker {
+public interface KeyMaker {
 
-    fun <M : Any> newKey(type: KClass<M>, vararg id: Any): Key<M>
+    public fun <M : Any> newKey(type: KClass<M>, vararg id: Any): Key<M>
 
-    fun <M : Any> newKeyFrom(model: M, vararg options: Options.Write): Key<M>
+    public fun <M : Any> newKeyFrom(model: M, vararg options: Options.Write): Key<M>
 
-    fun <M : Any> newKeyFromB64(type: KClass<M>, b64: String): Key<M>
+    public fun <M : Any> newKeyFromB64(type: KClass<M>, b64: String): Key<M>
 }
 
-inline fun <reified M : Any> KeyMaker.newKey(vararg id: Any) = newKey(M::class, *id)
-inline fun <reified M : Any> KeyMaker.newKeyFromB64(b64: String) = newKeyFromB64(M::class, b64)
+public inline fun <reified M : Any> KeyMaker.newKey(vararg id: Any): Key<M> = newKey(M::class, *id)
+public inline fun <reified M : Any> KeyMaker.newKeyFromB64(b64: String): Key<M> = newKeyFromB64(M::class, b64)

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Middleware.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Middleware.kt
@@ -4,14 +4,14 @@ import org.kodein.db.data.DataDB
 import org.kodein.db.leveldb.LevelDB
 import org.kodein.db.model.ModelDB
 
-typealias ModelMiddleware = ((ModelDB) -> ModelDB)
-typealias DataMiddleware = ((DataDB) -> DataDB)
-typealias LevelMiddleware = ((LevelDB) -> LevelDB)
+public typealias ModelMiddleware = ((ModelDB) -> ModelDB)
+public typealias DataMiddleware = ((DataDB) -> DataDB)
+public typealias LevelMiddleware = ((LevelDB) -> LevelDB)
 
-interface Middleware {
+public interface Middleware {
 
-    class Level(val middleware: LevelMiddleware) : Options.Open
-    class Data(val middleware: DataMiddleware) : Options.Open
-    class Model(val middleware: ModelMiddleware) : Options.Open
+    public class Level(public val middleware: LevelMiddleware) : Options.Open
+    public class Data(public val middleware: DataMiddleware) : Options.Open
+    public class Model(public val middleware: ModelMiddleware) : Options.Open
 
 }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Options.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Options.kt
@@ -1,19 +1,19 @@
 package org.kodein.db
 import kotlin.collections.plus as kotlinPlus
 
-interface Options {
+public interface Options {
 
-    interface Read : Options
+    public interface Read : Options
 
-    interface Write : Options
+    public interface Write : Options
 
-    interface Open : Options
+    public interface Open : Options
 }
 
-inline operator fun <reified T : Options> Array<out Options>.invoke() = firstOrNull { it is T } as T?
-inline fun <reified T : Options> Array<out Options>.all() = filterIsInstance<T>()
+public inline operator fun <reified T : Options> Array<out Options>.invoke(): T? = firstOrNull { it is T } as T?
+public inline fun <reified T : Options> Array<out Options>.all(): List<T> = filterIsInstance<T>()
 
 @Suppress("UNCHECKED_CAST")
 //fun <T : Options> Array<out T>.and(add: T) = (this as Array<T>) + add
 
-operator fun <T : Options> Array<out T>.plus(add: T) = (this as Array<T>).kotlinPlus(add)
+public operator fun <T : Options> Array<out T>.plus(add: T): Array<T> = (this as Array<T>).kotlinPlus(add)

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/SizedModel.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/SizedModel.kt
@@ -1,18 +1,18 @@
 package org.kodein.db
 
-interface Sized<out M> {
-    val model: M
-    val size: Int
+public interface Sized<out M> {
+    public val model: M
+    public val size: Int
 
-    operator fun component1() = model
-    operator fun component2() = size
+    public operator fun component1(): M = model
+    public operator fun component2(): Int = size
 
     private data class Impl<M>(override val model: M, override val size: Int) : Sized<M>
 
-    companion object {
-        operator fun <M> invoke(value: M, size: Int): Sized<M> = Impl(value, size)
+    public companion object {
+        public operator fun <M> invoke(value: M, size: Int): Sized<M> = Impl(value, size)
     }
 
 }
 
-data class KeyAndSize<M : Any>(val key: Key<M>, val size: Int)
+public data class KeyAndSize<M : Any>(val key: Key<M>, val size: Int)

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Snapshot.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Snapshot.kt
@@ -2,4 +2,4 @@ package org.kodein.db
 
 import org.kodein.memory.Closeable
 
-interface Snapshot : DBRead, Closeable
+public interface Snapshot : DBRead, Closeable

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/TypeTable.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/TypeTable.kt
@@ -5,15 +5,15 @@ import org.kodein.memory.io.ReadMemory
 import org.kodein.memory.io.wrap
 import kotlin.reflect.KClass
 
-interface TypeTable : Options.Open {
+public interface TypeTable : Options.Open {
 
-    fun getTypeName(type: KClass<*>): ReadMemory
+    public fun getTypeName(type: KClass<*>): ReadMemory
 
-    fun getTypeClass(name: ReadMemory): KClass<*>?
+    public fun getTypeClass(name: ReadMemory): KClass<*>?
 
-    fun getRegisteredClasses(): Set<KClass<*>>
+    public fun getRegisteredClasses(): Set<KClass<*>>
 
-    fun getRootOf(type: KClass<*>): KClass<*>?
+    public fun getRootOf(type: KClass<*>): KClass<*>?
 
     private class Impl(roots: Iterable<Type.Root<*>>, val defaultNameOf: (KClass<*>) -> ReadMemory, val defaultClassOf: (ReadMemory) -> KClass<*>?) : TypeTable {
 
@@ -51,34 +51,34 @@ interface TypeTable : Options.Open {
 
     }
 
-    sealed class Type<T : Any>(val type: KClass<T>, val name: ReadMemory) {
-        class Sub<T : Any>(type: KClass<T>, name: ReadMemory) : Type<T>(type, name)
-        class Root<T : Any>(type: KClass<T>, name: ReadMemory, val subs: List<Sub<out T>>) : Type<T>(type, name)
+    public sealed class Type<T : Any>(public val type: KClass<T>, public val name: ReadMemory) {
+        public class Sub<T : Any>(type: KClass<T>, name: ReadMemory) : Type<T>(type, name)
+        public class Root<T : Any>(type: KClass<T>, name: ReadMemory, public val subs: List<Sub<out T>>) : Type<T>(type, name)
     }
 
-    class Builder internal constructor(val defaultNameOf: (KClass<*>) -> ReadMemory) {
+    public class Builder internal constructor(public val defaultNameOf: (KClass<*>) -> ReadMemory) {
 
         internal val roots = ArrayList<Type.Root<*>>()
 
-        fun <T: Any> root(type: KClass<T>, name: ReadMemory = defaultNameOf(type)): Root<T> {
+        public fun <T: Any> root(type: KClass<T>, name: ReadMemory = defaultNameOf(type)): Root<T> {
             val root = Root<T>(defaultNameOf)
             roots += Type.Root(type, name, root.subs)
             return root
         }
 
-        inline fun <reified T: Any> root(name: ReadMemory = defaultNameOf(T::class)) = root(T::class, name)
+        public inline fun <reified T: Any> root(name: ReadMemory = defaultNameOf(T::class)): Root<T> = root(T::class, name)
 
-        class Root<T : Any>(val defaultNameOf: (KClass<*>) -> ReadMemory) {
+        public class Root<T : Any>(public val defaultNameOf: (KClass<*>) -> ReadMemory) {
 
             internal val subs = ArrayList<Type.Sub<out T>>()
 
-            fun <S : T> sub(type: KClass<S>, name: ReadMemory = defaultNameOf(type)) = apply { subs += Type.Sub(type, name) }
+            public fun <S : T> sub(type: KClass<S>, name: ReadMemory = defaultNameOf(type)): Root<T> = apply { subs += Type.Sub(type, name) }
 
-            inline fun <reified S: T> sub(name: ReadMemory = defaultNameOf(S::class)) = sub(S::class, name)
+            public inline fun <reified S: T> sub(name: ReadMemory = defaultNameOf(S::class)): Root<T> = sub(S::class, name)
         }
     }
 
-    companion object {
-        operator fun invoke(defaultNameOf: (KClass<*>) -> ReadMemory = { KBuffer.wrap(simpleTypeAsciiNameOf(it)) }, defaultClassOf: (ReadMemory) -> KClass<*>? = { null }, builder: Builder.() -> Unit = {}): TypeTable = Impl(Builder(defaultNameOf).apply(builder).roots, defaultNameOf, defaultClassOf)
+    public companion object {
+        public operator fun invoke(defaultNameOf: (KClass<*>) -> ReadMemory = { KBuffer.wrap(simpleTypeAsciiNameOf(it)) }, defaultClassOf: (ReadMemory) -> KClass<*>? = { null }, builder: Builder.() -> Unit = {}): TypeTable = Impl(Builder(defaultNameOf).apply(builder).roots, defaultNameOf, defaultClassOf)
     }
 }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Value.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Value.kt
@@ -5,11 +5,11 @@ import org.kodein.memory.io.*
 import org.kodein.memory.util.UUID
 import org.kodein.memory.util.putUUID
 
-interface Value : Body {
+public interface Value : Body {
 
-    val size: Int
+    public val size: Int
 
-    abstract class AbstractValue : Value {
+    public abstract class AbstractValue : Value {
 
         private var _hashCode = 0
 
@@ -42,7 +42,7 @@ interface Value : Body {
         }
     }
 
-    abstract class ZeroSpacedValues(private val _count: Int) : AbstractValue(), Value {
+    public abstract class ZeroSpacedValues(private val _count: Int) : AbstractValue(), Value {
 
         final override fun writeInto(dst: Writeable) {
             for (i in 0 until _count) {
@@ -63,14 +63,14 @@ interface Value : Body {
         protected abstract fun size(pos: Int): Int
     }
 
-    companion object {
+    public companion object {
 
-        val emptyValue: Value = object : Value {
+        public val emptyValue: Value = object : Value {
             override val size = 0
             override fun writeInto(dst: Writeable) {}
         }
 
-        fun of(vararg values: ByteArray): Value {
+        public fun of(vararg values: ByteArray): Value {
             return object : Value.ZeroSpacedValues(values.size) {
                 override fun write(dst: Writeable, pos: Int) {
                     dst.putBytes(values[pos], 0, values[pos].size)
@@ -80,7 +80,7 @@ interface Value : Body {
             }
         }
 
-        fun of(vararg values: ReadBuffer): Value {
+        public fun of(vararg values: ReadBuffer): Value {
             return object : Value.ZeroSpacedValues(values.size) {
                 override fun write(dst: Writeable, pos: Int) {
                     dst.putBytes(values[pos].duplicate())
@@ -90,7 +90,7 @@ interface Value : Body {
             }
         }
 
-        fun of(vararg values: Value): Value {
+        public fun of(vararg values: Value): Value {
             return object : Value.ZeroSpacedValues(values.size) {
                 override fun write(dst: Writeable, pos: Int) {
                     val value = values[pos]
@@ -101,7 +101,7 @@ interface Value : Body {
             }
         }
 
-        fun of(vararg values: Boolean): Value {
+        public fun of(vararg values: Boolean): Value {
             return object : Value.ZeroSpacedValues(values.size) {
                 override fun write(dst: Writeable, pos: Int) {
                     dst.putByte((if (values[pos]) 1 else 0).toByte())
@@ -111,7 +111,7 @@ interface Value : Body {
             }
         }
 
-        fun of(vararg values: Byte): Value {
+        public fun of(vararg values: Byte): Value {
             return object : Value.ZeroSpacedValues(values.size) {
                 override fun write(dst: Writeable, pos: Int) {
                     dst.putByte(values[pos])
@@ -121,7 +121,7 @@ interface Value : Body {
             }
         }
 
-        fun of(vararg values: Short): Value {
+        public fun of(vararg values: Short): Value {
             return object : Value.ZeroSpacedValues(values.size) {
                 override fun write(dst: Writeable, pos: Int) {
                     dst.putShort(values[pos])
@@ -131,7 +131,7 @@ interface Value : Body {
             }
         }
 
-        fun of(vararg values: Int): Value {
+        public fun of(vararg values: Int): Value {
             return object : Value.ZeroSpacedValues(values.size) {
                 override fun write(dst: Writeable, pos: Int) {
                     dst.putInt(values[pos])
@@ -141,7 +141,7 @@ interface Value : Body {
             }
         }
 
-        fun of(vararg values: Long): Value {
+        public fun of(vararg values: Long): Value {
             return object : Value.ZeroSpacedValues(values.size) {
                 override fun write(dst: Writeable, pos: Int) {
                     dst.putLong(values[pos])
@@ -151,7 +151,7 @@ interface Value : Body {
             }
         }
 
-        fun of(vararg values: UUID): Value {
+        public fun of(vararg values: UUID): Value {
             return object : Value.ZeroSpacedValues(values.size) {
                 override fun write(dst: Writeable, pos: Int) {
                     dst.putUUID(values[pos])
@@ -161,7 +161,7 @@ interface Value : Body {
             }
         }
 
-        fun ofAscii(vararg values: Char): Value {
+        public fun ofAscii(vararg values: Char): Value {
             return object : Value.ZeroSpacedValues(values.size) {
                 override fun write(dst: Writeable, pos: Int) {
                     dst.putByte(values[pos].toByte())
@@ -172,7 +172,7 @@ interface Value : Body {
         }
 
 
-        fun ofAscii(vararg values: CharSequence): Value {
+        public fun ofAscii(vararg values: CharSequence): Value {
             return object : Value.ZeroSpacedValues(values.size) {
                 override fun write(dst: Writeable, pos: Int) {
                     dst.putAscii(values[pos])
@@ -198,7 +198,7 @@ interface Value : Body {
             else -> throw IllegalArgumentException("invalid value: $this")
         }
 
-        fun ofAll(vararg values: Any): Value {
+        public fun ofAll(vararg values: Any): Value {
             if (values.isEmpty())
                 return emptyValue
 
@@ -213,7 +213,7 @@ interface Value : Body {
         }
 
         @Suppress("UNCHECKED_CAST")
-        fun ofAny(value: Any): Value = when (value) {
+        public fun ofAny(value: Any): Value = when (value) {
             is Collection<*> ->
                 if (value.size == 1) value.requireNoNulls().first().toValue()
                 else ofAll(*value.toTypedArray().requireNoNulls())

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/ascii/ascii.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/ascii/ascii.kt
@@ -4,12 +4,12 @@ import org.kodein.memory.io.ReadMemory
 import org.kodein.memory.io.Writeable
 
 
-fun Writeable.putAscii(str: CharSequence) {
+public fun Writeable.putAscii(str: CharSequence) {
     for (char in str)
         putByte(char.toByte())
 }
 
-fun ReadMemory.getAscii(start: Int = 0, size: Int = limit - start): String {
+public fun ReadMemory.getAscii(start: Int = 0, size: Int = limit - start): String {
     val array = CharArray(size)
     for (i in 0 until size)
         array[i] = get(start + i).toChar()

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/callbacks.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/callbacks.kt
@@ -1,5 +1,5 @@
 package org.kodein.db
 
-class Anticipate(val needsLock: Boolean = false, val block: () -> Unit) : Options.Write
+public class Anticipate(public val needsLock: Boolean = false, public val block: () -> Unit) : Options.Write
 
-class React(val needsLock: Boolean = false, val block: (Int) -> Unit) : Options.Write
+public class React(public val needsLock: Boolean = false, public val block: (Int) -> Unit) : Options.Write

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/data/DataBatch.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/data/DataBatch.kt
@@ -5,6 +5,6 @@ import org.kodein.memory.Closeable
 import org.kodein.memory.util.MaybeThrowable
 
 
-interface DataBatch : DataWrite, Closeable {
-    fun write(afterErrors: MaybeThrowable, vararg options: Options.Write)
+public interface DataBatch : DataWrite, Closeable {
+    public fun write(afterErrors: MaybeThrowable, vararg options: Options.Write)
 }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/data/DataCursor.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/data/DataCursor.kt
@@ -3,11 +3,11 @@ package org.kodein.db.data
 import org.kodein.db.BaseCursor
 import org.kodein.memory.io.ReadMemory
 
-interface DataCursor : BaseCursor {
+public interface DataCursor : BaseCursor {
 
-    fun transientKey(): ReadMemory
-    fun transientValue(): ReadMemory
+    public fun transientKey(): ReadMemory
+    public fun transientValue(): ReadMemory
 
-    fun duplicate(): DataCursor
+    public fun duplicate(): DataCursor
 
 }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/data/DataDB.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/data/DataDB.kt
@@ -4,13 +4,13 @@ import org.kodein.db.Options
 import org.kodein.db.leveldb.LevelDB
 import org.kodein.memory.Closeable
 
-interface DataDB : DataWrite, DataRead, Closeable {
+public interface DataDB : DataWrite, DataRead, Closeable {
 
-    val ldb: LevelDB
+    public val ldb: LevelDB
 
-    fun newBatch(): DataBatch
+    public fun newBatch(): DataBatch
 
-    fun newSnapshot(vararg options: Options.Read): DataSnapshot
+    public fun newSnapshot(vararg options: Options.Read): DataSnapshot
 
-    companion object
+    public companion object
 }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/data/DataKeyMaker.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/data/DataKeyMaker.kt
@@ -3,8 +3,8 @@ package org.kodein.db.data
 import org.kodein.db.Value
 import org.kodein.memory.io.KBuffer
 
-interface DataKeyMaker {
+public interface DataKeyMaker {
 
-    fun newKey(type: Int, id: Value): KBuffer
+    public fun newKey(type: Int, id: Value): KBuffer
 
 }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/data/DataRead.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/data/DataRead.kt
@@ -5,28 +5,28 @@ import org.kodein.db.Value
 import org.kodein.memory.io.Allocation
 import org.kodein.memory.io.ReadMemory
 
-interface DataRead : DataKeyMaker {
+public interface DataRead : DataKeyMaker {
 
-    fun get(key: ReadMemory, vararg options: Options.Read): Allocation?
+    public fun get(key: ReadMemory, vararg options: Options.Read): Allocation?
 
-    fun findAll(vararg options: Options.Read): DataCursor
+    public fun findAll(vararg options: Options.Read): DataCursor
 
-    fun findAllByType(type: Int, vararg options: Options.Read): DataCursor
+    public fun findAllByType(type: Int, vararg options: Options.Read): DataCursor
 
-    fun findById(type: Int, id: Value, isOpen: Boolean = false, vararg options: Options.Read): DataCursor
+    public fun findById(type: Int, id: Value, isOpen: Boolean = false, vararg options: Options.Read): DataCursor
 
-    fun findAllByIndex(type: Int, index: String, vararg options: Options.Read): DataCursor
+    public fun findAllByIndex(type: Int, index: String, vararg options: Options.Read): DataCursor
 
-    fun findByIndex(type: Int, index: String, value: Value, isOpen: Boolean = false, vararg options: Options.Read): DataCursor
+    public fun findByIndex(type: Int, index: String, value: Value, isOpen: Boolean = false, vararg options: Options.Read): DataCursor
 
-    fun getIndexesOf(key: ReadMemory, vararg options: Options.Read): Set<String>
+    public fun getIndexesOf(key: ReadMemory, vararg options: Options.Read): Set<String>
 
     /**
      * If true, all data read from underlying storage will be verified against corresponding checksums.
      *
      * (Default: false)
      */
-    data class VerifyChecksum(val verifyChecksums: Boolean) : Options.Read
+    public data class VerifyChecksum(val verifyChecksums: Boolean) : Options.Read
 
     /**
      * Should the data read for this iteration be cached in memory?
@@ -35,6 +35,6 @@ interface DataRead : DataKeyMaker {
      *
      * (Default: true)
      */
-    data class FillCache(val fillCache: Boolean) : Options.Read
+    public data class FillCache(val fillCache: Boolean) : Options.Read
 
 }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/data/DataSnapshot.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/data/DataSnapshot.kt
@@ -3,4 +3,4 @@ package org.kodein.db.data
 import org.kodein.memory.Closeable
 
 
-interface DataSnapshot : DataRead, Closeable
+public interface DataSnapshot : DataRead, Closeable

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/data/DataWrite.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/data/DataWrite.kt
@@ -5,11 +5,11 @@ import org.kodein.db.Index
 import org.kodein.db.Options
 import org.kodein.memory.io.ReadMemory
 
-interface DataWrite : DataKeyMaker {
+public interface DataWrite : DataKeyMaker {
 
-    fun put(key: ReadMemory, body: Body, indexes: Set<Index> = emptySet(), vararg options: Options.Write): Int
+    public fun put(key: ReadMemory, body: Body, indexes: Set<Index> = emptySet(), vararg options: Options.Write): Int
 
-    fun delete(key: ReadMemory, vararg options: Options.Write)
+    public fun delete(key: ReadMemory, vararg options: Options.Write)
 
     /**
      * If true, the write will be flushed from the operating system buffer cache (by calling WritableFile::Sync()) before the write is considered complete.
@@ -24,6 +24,6 @@ interface DataWrite : DataKeyMaker {
      *
      * (Default: false)
      */
-    data class Sync(val sync: Boolean = false) : Options.Write
+    public data class Sync(val sync: Boolean = false) : Options.Write
 
 }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/expect.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/expect.kt
@@ -2,6 +2,6 @@ package org.kodein.db
 
 import kotlin.reflect.KClass
 
-expect fun simpleTypeNameOf(type: KClass<*>): String
+public expect fun simpleTypeNameOf(type: KClass<*>): String
 
-fun simpleTypeAsciiNameOf(type: KClass<*>) = simpleTypeNameOf(type).let { name -> ByteArray(name.length) { name[it].toByte() } }
+public fun simpleTypeAsciiNameOf(type: KClass<*>): ByteArray = simpleTypeNameOf(type).let { name -> ByteArray(name.length) { name[it].toByte() } }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/ldb/LevelDBOptions.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/ldb/LevelDBOptions.kt
@@ -6,7 +6,7 @@ import org.kodein.log.LoggerFactory
 
 
 @Suppress("unused")
-sealed class LevelDBOptions(internal val transform: LevelDB.Options.() -> LevelDB.Options) : Options.Open {
+public sealed class LevelDBOptions(internal val transform: LevelDB.Options.() -> LevelDB.Options) : Options.Open {
 
     /**
      * Defines how to react if the database exists or not.
@@ -15,7 +15,7 @@ sealed class LevelDBOptions(internal val transform: LevelDB.Options.() -> LevelD
      *
      * @see OpenPolicy
      */
-    data class OpenPolicy(val openPolicy: LevelDB.OpenPolicy): LevelDBOptions({ copy(openPolicy = openPolicy) })
+    public data class OpenPolicy(val openPolicy: LevelDB.OpenPolicy): LevelDBOptions({ copy(openPolicy = openPolicy) })
 
     /**
      * If true, the implementation will do aggressive checking of the data it is processing and will stop early if it detects any errors.
@@ -24,7 +24,7 @@ sealed class LevelDBOptions(internal val transform: LevelDB.Options.() -> LevelD
      *
      * (Default: false)
      */
-    data class ParanoidChecks(val paranoidChecks: Boolean): LevelDBOptions({ copy(paranoidChecks = paranoidChecks) })
+    public data class ParanoidChecks(val paranoidChecks: Boolean): LevelDBOptions({ copy(paranoidChecks = paranoidChecks) })
 
     /**
      * If true, the LevelDB implementation will print internal logs.
@@ -33,7 +33,7 @@ sealed class LevelDBOptions(internal val transform: LevelDB.Options.() -> LevelD
      *
      * (Default: false)
      */
-    data class PrintLogs(val printLogs: Boolean = false): LevelDBOptions({ copy(printLogs = printLogs) })
+    public data class PrintLogs(val printLogs: Boolean = false): LevelDBOptions({ copy(printLogs = printLogs) })
 
     /**
      * Amount of data to build up in memory (backed by an unsorted log on disk) before converting to a sorted on-disk file.
@@ -44,7 +44,7 @@ sealed class LevelDBOptions(internal val transform: LevelDB.Options.() -> LevelD
      *
      * (Default: 4MB)
      */
-    data class WriteBufferSize(val writeBufferSize: Int): LevelDBOptions({ copy(writeBufferSize = writeBufferSize) })
+    public data class WriteBufferSize(val writeBufferSize: Int): LevelDBOptions({ copy(writeBufferSize = writeBufferSize) })
 
     /**
      * Number of open files that can be used by the DB.
@@ -53,14 +53,14 @@ sealed class LevelDBOptions(internal val transform: LevelDB.Options.() -> LevelD
      *
      * (Default: 1000)
      */
-    data class MaxOpenFiled(val maxOpenFiles: Int): LevelDBOptions({ copy(maxOpenFiles = maxOpenFiles) })
+    public data class MaxOpenFiled(val maxOpenFiles: Int): LevelDBOptions({ copy(maxOpenFiles = maxOpenFiles) })
 
     /**
      * Size of the LRU cache LevelDB will use to prevent unneeded disk access.
      *
      * (Default: 8MB)
      */
-    data class CacheSize(val cacheSize: Int): LevelDBOptions({ copy(cacheSize = cacheSize) })
+    public data class CacheSize(val cacheSize: Int): LevelDBOptions({ copy(cacheSize = cacheSize) })
 
     /**
      * Approximate size of user data packed per block.
@@ -72,7 +72,7 @@ sealed class LevelDBOptions(internal val transform: LevelDB.Options.() -> LevelD
      *
      * (Default: 4K)
      */
-    data class BlockSize(val blockSize: Int): LevelDBOptions({ copy(blockSize = blockSize) })
+    public data class BlockSize(val blockSize: Int): LevelDBOptions({ copy(blockSize = blockSize) })
 
     /**
      * Number of keys between restart points for delta encoding of keys.
@@ -83,7 +83,7 @@ sealed class LevelDBOptions(internal val transform: LevelDB.Options.() -> LevelD
      *
      * (Default: 16)
      */
-    data class BlockRestartInterval(val blockRestartInterval: Int): LevelDBOptions({ copy(blockRestartInterval = blockRestartInterval) })
+    public data class BlockRestartInterval(val blockRestartInterval: Int): LevelDBOptions({ copy(blockRestartInterval = blockRestartInterval) })
 
     /**
      * Leveldb will write up to this amount of bytes to a file before switching to a new one.
@@ -95,7 +95,7 @@ sealed class LevelDBOptions(internal val transform: LevelDB.Options.() -> LevelD
      *
      * (Default: 2MB)
      */
-    data class MaxFileSize(val maxFileSize: Int): LevelDBOptions({ copy(maxFileSize = maxFileSize) })
+    public data class MaxFileSize(val maxFileSize: Int): LevelDBOptions({ copy(maxFileSize = maxFileSize) })
 
     /**
      * Whether to compress blocks using the Snappy compression algorithm.
@@ -114,7 +114,7 @@ sealed class LevelDBOptions(internal val transform: LevelDB.Options.() -> LevelD
      *
      * (Default: true)
      */
-    data class SnappyCompression(val snappyCompression: Boolean): LevelDBOptions({ copy(snappyCompression = snappyCompression) })
+    public data class SnappyCompression(val snappyCompression: Boolean): LevelDBOptions({ copy(snappyCompression = snappyCompression) })
 
     /**
      * EXPERIMENTAL: If true, append to existing MANIFEST and log files
@@ -122,7 +122,7 @@ sealed class LevelDBOptions(internal val transform: LevelDB.Options.() -> LevelD
      *
      * Default: currently false, but may become true later.
      */
-    data class ReuseLogs(val reuseLogs: Boolean): LevelDBOptions({ copy(reuseLogs = reuseLogs) })
+    public data class ReuseLogs(val reuseLogs: Boolean): LevelDBOptions({ copy(reuseLogs = reuseLogs) })
 
     /**
      * If non-0, use a Bloom filter policy to reduce disk reads.
@@ -132,23 +132,23 @@ sealed class LevelDBOptions(internal val transform: LevelDB.Options.() -> LevelD
      *
      * (Default: 10)
      */
-    data class BloomFilterBitsPerKey(val bloomFilterBitsPerKey: Int): LevelDBOptions({ copy(bloomFilterBitsPerKey = bloomFilterBitsPerKey) })
+    public data class BloomFilterBitsPerKey(val bloomFilterBitsPerKey: Int): LevelDBOptions({ copy(bloomFilterBitsPerKey = bloomFilterBitsPerKey) })
 
     /**
      * If a DB cannot be opened, you may attempt to set this to true to resurrect as much of the contents of the database as possible.
      *
      * Some data may be lost, so be careful when setting this on a database that contains important information.
      */
-    data class RepairOnCorruption(val repairOnCorruption: Boolean): LevelDBOptions({ copy(repairOnCorruption = repairOnCorruption) })
+    public data class RepairOnCorruption(val repairOnCorruption: Boolean): LevelDBOptions({ copy(repairOnCorruption = repairOnCorruption) })
 
-    companion object {
-        fun new(options: Array<out Options.Open>) = options.filterIsInstance<LevelDBOptions>().fold(LevelDB.Options.DEFAULT) { l, o -> o.transform(l) }
+    public companion object {
+        public fun new(options: Array<out Options.Open>): LevelDB.Options = options.filterIsInstance<LevelDBOptions>().fold(LevelDB.Options.DEFAULT) { l, o -> o.transform(l) }
     }
 
 }
 
-data class DBLoggerFactory(val loggerFactory: LoggerFactory): LevelDBOptions({ copy(loggerFactory = loggerFactory) })
+public data class DBLoggerFactory(val loggerFactory: LoggerFactory): LevelDBOptions({ copy(loggerFactory = loggerFactory) })
 
-data class TrackClosableAllocation(val trackClosableAllocation: Boolean): LevelDBOptions({ copy(trackClosableAllocation = trackClosableAllocation) })
+public data class TrackClosableAllocation(val trackClosableAllocation: Boolean): LevelDBOptions({ copy(trackClosableAllocation = trackClosableAllocation) })
 
-data class FailOnBadClose(val failOnBadClose: Boolean): LevelDBOptions({ copy(failOnBadClose = failOnBadClose) })
+public data class FailOnBadClose(val failOnBadClose: Boolean): LevelDBOptions({ copy(failOnBadClose = failOnBadClose) })

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/ModelBatch.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/ModelBatch.kt
@@ -4,6 +4,6 @@ import org.kodein.db.Options
 import org.kodein.memory.Closeable
 import org.kodein.memory.util.MaybeThrowable
 
-interface ModelBatch : ModelWrite, Closeable {
-    fun write(afterErrors: MaybeThrowable, vararg options: Options.Write)
+public interface ModelBatch : ModelWrite, Closeable {
+    public fun write(afterErrors: MaybeThrowable, vararg options: Options.Write)
 }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/ModelCursor.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/ModelCursor.kt
@@ -5,11 +5,11 @@ import org.kodein.db.Key
 import org.kodein.db.Options
 import org.kodein.db.Sized
 
-interface ModelCursor<M : Any> : BaseCursor {
+public interface ModelCursor<M : Any> : BaseCursor {
 
-    fun key(): Key<M>
-    fun model(vararg options: Options.Read): Sized<M>
+    public fun key(): Key<M>
+    public fun model(vararg options: Options.Read): Sized<M>
 
-    fun duplicate(): ModelCursor<M>
+    public fun duplicate(): ModelCursor<M>
 
 }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/ModelDB.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/ModelDB.kt
@@ -4,14 +4,14 @@ import org.kodein.db.DBListener
 import org.kodein.db.Options
 import org.kodein.memory.Closeable
 
-interface ModelDB : ModelWrite, ModelRead, Closeable {
+public interface ModelDB : ModelWrite, ModelRead, Closeable {
 
-    fun newBatch(): ModelBatch
+    public fun newBatch(): ModelBatch
 
-    fun newSnapshot(vararg options: Options.Read): ModelSnapshot
+    public fun newSnapshot(vararg options: Options.Read): ModelSnapshot
 
-    fun register(listener: DBListener<Any>): Closeable
+    public fun register(listener: DBListener<Any>): Closeable
 
-    companion object
+    public companion object
 }
 

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/ModelRead.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/ModelRead.kt
@@ -3,29 +3,29 @@ package org.kodein.db.model
 import org.kodein.db.*
 import kotlin.reflect.KClass
 
-interface ModelRead : KeyMaker {
+public interface ModelRead : KeyMaker {
 
-    operator fun <M : Any> get(type: KClass<M>, key: Key<M>, vararg options: Options.Read): Sized<M>?
+    public operator fun <M : Any> get(type: KClass<M>, key: Key<M>, vararg options: Options.Read): Sized<M>?
 
-    fun findAll(vararg options: Options.Read): ModelCursor<*>
+    public fun findAll(vararg options: Options.Read): ModelCursor<*>
 
-    fun <M : Any> findAllByType(type: KClass<M>, vararg options: Options.Read): ModelCursor<M>
+    public fun <M : Any> findAllByType(type: KClass<M>, vararg options: Options.Read): ModelCursor<M>
 
-    fun <M : Any> findById(type: KClass<M>, id: Any, isOpen: Boolean = false, vararg options: Options.Read): ModelCursor<M>
+    public fun <M : Any> findById(type: KClass<M>, id: Any, isOpen: Boolean = false, vararg options: Options.Read): ModelCursor<M>
 
-    fun <M : Any> findAllByIndex(type: KClass<M>, index: String, vararg options: Options.Read): ModelCursor<M>
+    public fun <M : Any> findAllByIndex(type: KClass<M>, index: String, vararg options: Options.Read): ModelCursor<M>
 
-    fun <M : Any> findByIndex(type: KClass<M>, index: String, value: Any, isOpen: Boolean = false, vararg options: Options.Read): ModelCursor<M>
+    public fun <M : Any> findByIndex(type: KClass<M>, index: String, value: Any, isOpen: Boolean = false, vararg options: Options.Read): ModelCursor<M>
 
-    fun getIndexesOf(key: Key<*>, vararg options: Options.Read): Set<String>
+    public fun getIndexesOf(key: Key<*>, vararg options: Options.Read): Set<String>
 }
 
-inline operator fun <reified M : Any> ModelRead.get(key: Key<M>, vararg options: Options.Read): Sized<M>? = get(M::class, key, *options)
+public inline operator fun <reified M : Any> ModelRead.get(key: Key<M>, vararg options: Options.Read): Sized<M>? = get(M::class, key, *options)
 
-inline fun <reified M : Any> ModelRead.findAllByType(vararg options: Options.Read) = findAllByType(M::class, *options)
+public inline fun <reified M : Any> ModelRead.findAllByType(vararg options: Options.Read): ModelCursor<M> = findAllByType(M::class, *options)
 
-inline fun <reified M : Any> ModelRead.findById(id: Any, isOpen: Boolean = false, vararg options: Options.Read) = findById(M::class, id, isOpen, *options)
+public inline fun <reified M : Any> ModelRead.findById(id: Any, isOpen: Boolean = false, vararg options: Options.Read): ModelCursor<M> = findById(M::class, id, isOpen, *options)
 
-inline fun <reified M : Any> ModelRead.findAllByIndex(index: String, vararg options: Options.Read) = findAllByIndex(M::class, index, *options)
+public inline fun <reified M : Any> ModelRead.findAllByIndex(index: String, vararg options: Options.Read): ModelCursor<M> = findAllByIndex(M::class, index, *options)
 
-inline fun <reified M : Any> ModelRead.findByIndex(index: String, value: Any, isOpen: Boolean = false, vararg options: Options.Read) = findByIndex(M::class, index, value, isOpen, *options)
+public inline fun <reified M : Any> ModelRead.findByIndex(index: String, value: Any, isOpen: Boolean = false, vararg options: Options.Read): ModelCursor<M> = findByIndex(M::class, index, value, isOpen, *options)

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/ModelSnapshot.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/ModelSnapshot.kt
@@ -2,4 +2,4 @@ package org.kodein.db.model
 
 import org.kodein.memory.Closeable
 
-interface ModelSnapshot : ModelRead, Closeable
+public interface ModelSnapshot : ModelRead, Closeable

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/ModelWrite.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/ModelWrite.kt
@@ -6,15 +6,15 @@ import org.kodein.db.KeyMaker
 import org.kodein.db.Options
 import kotlin.reflect.KClass
 
-interface ModelWrite : KeyMaker {
-    fun <M : Any> put(model: M, vararg options: Options.Write): KeyAndSize<M>
-    fun <M : Any> put(key: Key<M>, model: M, vararg options: Options.Write): Int
+public interface ModelWrite : KeyMaker {
+    public fun <M : Any> put(model: M, vararg options: Options.Write): KeyAndSize<M>
+    public fun <M : Any> put(key: Key<M>, model: M, vararg options: Options.Write): Int
 
-    fun <M : Any> delete(type: KClass<M>, key: Key<M>, vararg options: Options.Write)
+    public fun <M : Any> delete(type: KClass<M>, key: Key<M>, vararg options: Options.Write)
 }
 
-inline fun <reified M : Any> ModelWrite.delete(key: Key<M>, vararg options: Options.Write) = delete(M::class, key, *options)
+public inline fun <reified M : Any> ModelWrite.delete(key: Key<M>, vararg options: Options.Write): Unit = delete(M::class, key, *options)
 
-fun ModelWrite.putAll(models: Iterable<Any>, vararg options: Options.Write) = models.forEach { put(it, *options) }
+public fun ModelWrite.putAll(models: Iterable<Any>, vararg options: Options.Write): Unit = models.forEach { put(it, *options) }
 
-operator fun ModelWrite.plusAssign(model: Any) { put(model) }
+public operator fun ModelWrite.plusAssign(model: Any) { put(model) }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/Primitive.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/Primitive.kt
@@ -10,43 +10,43 @@ import org.kodein.memory.text.putString
 import org.kodein.memory.text.readString
 import kotlin.reflect.KClass
 
-data class IntPrimitive(override val id: Value, val value: Int) : Metadata {
-    constructor(id: Any, value: Int) : this(Value.ofAny(id), value)
-    object S : Serializer<IntPrimitive> {
+public data class IntPrimitive(override val id: Value, val value: Int) : Metadata {
+    public constructor(id: Any, value: Int) : this(Value.ofAny(id), value)
+    public object S : Serializer<IntPrimitive> {
         override fun serialize(model: IntPrimitive, output: Writeable, vararg options: Options.Write) { output.putInt(model.value) }
-        override fun deserialize(type: KClass<out IntPrimitive>, transientId: ReadMemory, input: ReadBuffer, vararg options: Options.Read) = IntPrimitive(Value.of(KBuffer.arrayCopy(transientId)), input.readInt())
+        override fun deserialize(type: KClass<out IntPrimitive>, transientId: ReadMemory, input: ReadBuffer, vararg options: Options.Read): IntPrimitive = IntPrimitive(Value.of(KBuffer.arrayCopy(transientId)), input.readInt())
     }
 }
 
-data class LongPrimitive(override val id: Value, val value: Long) : Metadata {
-    constructor(id: Any, value: Long) : this(Value.ofAny(id), value)
-    object S : Serializer<LongPrimitive> {
+public data class LongPrimitive(override val id: Value, val value: Long) : Metadata {
+    public constructor(id: Any, value: Long) : this(Value.ofAny(id), value)
+    public object S : Serializer<LongPrimitive> {
         override fun serialize(model: LongPrimitive, output: Writeable, vararg options: Options.Write) { output.putLong(model.value) }
-        override fun deserialize(type: KClass<out LongPrimitive>, transientId: ReadMemory, input: ReadBuffer, vararg options: Options.Read) = LongPrimitive(Value.of(KBuffer.arrayCopy(transientId)), input.readLong())
+        override fun deserialize(type: KClass<out LongPrimitive>, transientId: ReadMemory, input: ReadBuffer, vararg options: Options.Read): LongPrimitive = LongPrimitive(Value.of(KBuffer.arrayCopy(transientId)), input.readLong())
     }
 }
 
-data class DoublePrimitive(override val id: Value, val value: Double) : Metadata {
-    constructor(id: Any, value: Double) : this(Value.ofAny(id), value)
-    object S : Serializer<DoublePrimitive> {
+public data class DoublePrimitive(override val id: Value, val value: Double) : Metadata {
+    public constructor(id: Any, value: Double) : this(Value.ofAny(id), value)
+    public object S : Serializer<DoublePrimitive> {
         override fun serialize(model: DoublePrimitive, output: Writeable, vararg options: Options.Write) { output.putDouble(model.value) }
-        override fun deserialize(type: KClass<out DoublePrimitive>, transientId: ReadMemory, input: ReadBuffer, vararg options: Options.Read) = DoublePrimitive(Value.of(KBuffer.arrayCopy(transientId)), input.readDouble())
+        override fun deserialize(type: KClass<out DoublePrimitive>, transientId: ReadMemory, input: ReadBuffer, vararg options: Options.Read): DoublePrimitive = DoublePrimitive(Value.of(KBuffer.arrayCopy(transientId)), input.readDouble())
     }
 }
 
-data class StringPrimitive(override val id: Value, val value: String) : Metadata {
-    constructor(id: Any, value: String) : this(Value.ofAny(id), value)
-    object S : Serializer<StringPrimitive> {
+public data class StringPrimitive(override val id: Value, val value: String) : Metadata {
+    public constructor(id: Any, value: String) : this(Value.ofAny(id), value)
+    public object S : Serializer<StringPrimitive> {
         override fun serialize(model: StringPrimitive, output: Writeable, vararg options: Options.Write) { output.putString(model.value, Charset.UTF8) }
-        override fun deserialize(type: KClass<out StringPrimitive>, transientId: ReadMemory, input: ReadBuffer, vararg options: Options.Read) = StringPrimitive(Value.of(KBuffer.arrayCopy(transientId)), input.readString(Charset.UTF8))
+        override fun deserialize(type: KClass<out StringPrimitive>, transientId: ReadMemory, input: ReadBuffer, vararg options: Options.Read): StringPrimitive = StringPrimitive(Value.of(KBuffer.arrayCopy(transientId)), input.readString(Charset.UTF8))
     }
 }
 
-data class BytesPrimitive(override val id: Value, val value: ByteArray) : Metadata {
-    constructor(id: Any, value: ByteArray) : this(Value.ofAny(id), value)
-    object S : Serializer<BytesPrimitive> {
+public data class BytesPrimitive(override val id: Value, val value: ByteArray) : Metadata {
+    public constructor(id: Any, value: ByteArray) : this(Value.ofAny(id), value)
+    public object S : Serializer<BytesPrimitive> {
         override fun serialize(model: BytesPrimitive, output: Writeable, vararg options: Options.Write) { output.putBytes(model.value) }
-        override fun deserialize(type: KClass<out BytesPrimitive>, transientId: ReadMemory, input: ReadBuffer, vararg options: Options.Read) = BytesPrimitive(Value.of(KBuffer.arrayCopy(transientId)), input.readBytes())
+        override fun deserialize(type: KClass<out BytesPrimitive>, transientId: ReadMemory, input: ReadBuffer, vararg options: Options.Read): BytesPrimitive = BytesPrimitive(Value.of(KBuffer.arrayCopy(transientId)), input.readBytes())
     }
 
     override fun equals(other: Any?): Boolean {
@@ -59,12 +59,12 @@ data class BytesPrimitive(override val id: Value, val value: ByteArray) : Metada
 }
 
 @Suppress("FunctionName")
-fun Primitive(id: Any, value: Int) = IntPrimitive(id, value)
+public fun Primitive(id: Any, value: Int): IntPrimitive = IntPrimitive(id, value)
 @Suppress("FunctionName")
-fun Primitive(id: Any, value: Long) = LongPrimitive(id, value)
+public fun Primitive(id: Any, value: Long): LongPrimitive = LongPrimitive(id, value)
 @Suppress("FunctionName")
-fun Primitive(id: Any, value: Double) = DoublePrimitive(id, value)
+public fun Primitive(id: Any, value: Double): DoublePrimitive = DoublePrimitive(id, value)
 @Suppress("FunctionName")
-fun Primitive(id: Any, value: String) = StringPrimitive(id, value)
+public fun Primitive(id: Any, value: String): StringPrimitive = StringPrimitive(id, value)
 @Suppress("FunctionName")
-fun Primitive(id: Any, value: ByteArray) = BytesPrimitive(id, value)
+public fun Primitive(id: Any, value: ByteArray): BytesPrimitive = BytesPrimitive(id, value)

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/cache/BaseModelCache.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/cache/BaseModelCache.kt
@@ -3,26 +3,26 @@ package org.kodein.db.model.cache
 import org.kodein.db.Key
 import org.kodein.db.Sized
 
-interface BaseModelCache {
+public interface BaseModelCache {
 
-    fun <M : Any> getEntry(key: Key<M>): ModelCache.Entry<M>
+    public fun <M : Any> getEntry(key: Key<M>): ModelCache.Entry<M>
 
-    operator fun <M : Any> get(key: Key<M>): M? = getEntry(key).model
+    public operator fun <M : Any> get(key: Key<M>): M? = getEntry(key).model
 
-    fun <M : Any> getOrRetrieveEntry(key: Key<M>, retrieve: () -> Sized<M>?): ModelCache.Entry<M>
+    public fun <M : Any> getOrRetrieveEntry(key: Key<M>, retrieve: () -> Sized<M>?): ModelCache.Entry<M>
 
-    fun <M : Any> getOrRetrieve(key: Key<M>, retrieve: () -> Sized<M>?): M? = getOrRetrieveEntry(key, retrieve).model
+    public fun <M : Any> getOrRetrieve(key: Key<M>, retrieve: () -> Sized<M>?): M? = getOrRetrieveEntry(key, retrieve).model
 
-    fun <M : Any> put(key: Key<M>, value: M, size: Int)
+    public fun <M : Any> put(key: Key<M>, value: M, size: Int)
 
-    fun <M : Any> put(key: Key<M>, sized: Sized<M>) = put(key, sized.model, sized.size)
+    public fun <M : Any> put(key: Key<M>, sized: Sized<M>): Unit = put(key, sized.model, sized.size)
 
-    fun <M : Any> delete(key: Key<M>): ModelCache.Entry<M>
+    public fun <M : Any> delete(key: Key<M>): ModelCache.Entry<M>
 
-    fun <M : Any> evict(key: Key<M>): ModelCache.Entry<M>
+    public fun <M : Any> evict(key: Key<M>): ModelCache.Entry<M>
 
-    fun clear()
+    public fun clear()
 
-    fun batch(block: BaseModelCache.() -> Unit)
+    public fun batch(block: BaseModelCache.() -> Unit)
 
 }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/cache/ModelCache.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/cache/ModelCache.kt
@@ -3,36 +3,36 @@ package org.kodein.db.model.cache
 import org.kodein.db.Options
 import org.kodein.db.Sized
 
-interface ModelCache : BaseModelCache {
+public interface ModelCache : BaseModelCache {
 
-    object Disable : Options.Open
-    data class MaxSize(val maxSize: Long) : Options.Open
-    data class CopyMaxSize(val maxSize: Long) : Options.Open, Options.Read
-    object Skip : Options.Read, Options.Write
-    object Refresh : Options.Read
+    public object Disable : Options.Open
+    public data class MaxSize(val maxSize: Long) : Options.Open
+    public data class CopyMaxSize(val maxSize: Long) : Options.Open, Options.Read
+    public object Skip : Options.Read, Options.Write
+    public object Refresh : Options.Read
 
-    sealed class Entry<M : Any> {
-        abstract val model: M?
-        abstract val size: Int
+    public sealed class Entry<M : Any> {
+        public abstract val model: M?
+        public abstract val size: Int
 
-        data class Cached<M : Any>(override val model: M, override val size: Int) : Entry<M>(), Sized<M>
-        object Deleted : Entry<Nothing>() { override val model = null ; override val size: Int = 8 }
-        object NotInCache : Entry<Nothing>() { override val model = null ; override val size: Int = 0 }
+        public data class Cached<M : Any>(override val model: M, override val size: Int) : Entry<M>(), Sized<M>
+        public object Deleted : Entry<Nothing>() { override val model: Nothing? = null ; override val size: Int = 8 }
+        public object NotInCache : Entry<Nothing>() { override val model: Nothing? = null ; override val size: Int = 0 }
     }
 
-    val entryCount: Int
-    val size: Long
-    val maxSize: Long
+    public val entryCount: Int
+    public val size: Long
+    public val maxSize: Long
 
-    val hitCount: Int
-    val missCount: Int
-    val retrieveCount: Int
-    val putCount: Int
-    val deleteCount: Int
-    val evictionCount: Int
+    public val hitCount: Int
+    public val missCount: Int
+    public val retrieveCount: Int
+    public val putCount: Int
+    public val deleteCount: Int
+    public val evictionCount: Int
 
-    fun newCopy(copyMaxSize: Long): ModelCache
+    public fun newCopy(copyMaxSize: Long): ModelCache
 
-    companion object
+    public companion object
 
 }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/openOptions.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/openOptions.kt
@@ -4,5 +4,5 @@ import org.kodein.db.Options
 import org.kodein.db.model.orm.Serializer
 import kotlin.reflect.KClass
 
-class DBClassSerializer<M : Any>(val cls: KClass<M>, val serializer: Serializer<M>) : Options.Open
-inline operator fun <reified M : Any> Serializer<M>.unaryPlus() = DBClassSerializer(M::class, this)
+public class DBClassSerializer<M : Any>(public val cls: KClass<M>, public val serializer: Serializer<M>) : Options.Open
+public inline operator fun <reified M : Any> Serializer<M>.unaryPlus(): DBClassSerializer<M> = DBClassSerializer(M::class, this)

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/orm/FSerializer.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/orm/FSerializer.kt
@@ -7,10 +7,10 @@ import org.kodein.memory.io.Writeable
 import kotlin.reflect.KClass
 
 
-class FSerializer<M : Any>(private val serialize: Writeable.(M) -> Unit, private val deserialize: ReadBuffer.(KClass<out M>) -> M) : Serializer<M> {
+public class FSerializer<M : Any>(private val serialize: Writeable.(M) -> Unit, private val deserialize: ReadBuffer.(KClass<out M>) -> M) : Serializer<M> {
 
-    override fun serialize(model: M, output: Writeable, vararg options: Options.Write) = output.serialize(model)
+    override fun serialize(model: M, output: Writeable, vararg options: Options.Write): Unit = output.serialize(model)
 
-    override fun deserialize(type: KClass<out M>, transientId: ReadMemory, input: ReadBuffer, vararg options: Options.Read) = input.deserialize(type)
+    override fun deserialize(type: KClass<out M>, transientId: ReadMemory, input: ReadBuffer, vararg options: Options.Read): M = input.deserialize(type)
 }
 

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/orm/Metadata.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/orm/Metadata.kt
@@ -5,38 +5,38 @@ import org.kodein.db.Options
 import org.kodein.db.indexSet
 import org.kodein.db.model.ModelDB
 
-interface Metadata : HasMetadata {
-    val id: Any
-    fun indexes(): Set<Index> = emptySet()
+public interface Metadata : HasMetadata {
+    public val id: Any
+    public fun indexes(): Set<Index> = emptySet()
 
-    override fun getMetadata(db: ModelDB, vararg options: Options.Write) = this
+    override fun getMetadata(db: ModelDB, vararg options: Options.Write): Metadata = this
 
     private class Impl(override val id: Any, val indexes: Set<Index> = emptySet()) : Metadata {
         override fun indexes(): Set<Index> = indexes
     }
 
-    companion object {
-        operator fun invoke(id: Any, indexes: Set<Index>): Metadata = Impl(id, indexes)
-        operator fun invoke(id: Any, vararg indexes: Pair<String, Any>): Metadata = Impl(id, indexSet(*indexes))
+    public companion object {
+        public operator fun invoke(id: Any, indexes: Set<Index>): Metadata = Impl(id, indexes)
+        public operator fun invoke(id: Any, vararg indexes: Pair<String, Any>): Metadata = Impl(id, indexSet(*indexes))
     }
 }
 
-interface MetadataExtractor : Options.Open {
-    fun extractMetadata(model: Any, vararg options: Options.Write): Metadata
+public interface MetadataExtractor : Options.Open {
+    public fun extractMetadata(model: Any, vararg options: Options.Write): Metadata
 
-    companion object {
-        operator fun invoke(extractor: (Any) -> Metadata) = object : MetadataExtractor {
+    public companion object {
+        public operator fun invoke(extractor: (Any) -> Metadata): MetadataExtractor = object : MetadataExtractor {
             override fun extractMetadata(model: Any, vararg options: Options.Write): Metadata = extractor.invoke(model)
         }
     }
 }
 
-class NoMetadataExtractor : MetadataExtractor {
+public class NoMetadataExtractor : MetadataExtractor {
     override fun extractMetadata(model: Any, vararg options: Options.Write): Metadata =
             throw IllegalStateException("No Metadata extractor defined: models must implement HasMetadata")
 
 }
 
-interface HasMetadata {
-    fun getMetadata(db: ModelDB, vararg options: Options.Write): Metadata
+public interface HasMetadata {
+    public fun getMetadata(db: ModelDB, vararg options: Options.Write): Metadata
 }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/orm/Serializer.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/model/orm/Serializer.kt
@@ -6,9 +6,9 @@ import org.kodein.memory.io.ReadMemory
 import org.kodein.memory.io.Writeable
 import kotlin.reflect.KClass
 
-interface Serializer<M : Any> {
-    fun serialize(model: M, output: Writeable, vararg options: Options.Write)
-    fun deserialize(type: KClass<out M>, transientId: ReadMemory, input: ReadBuffer, vararg options: Options.Read): M
+public interface Serializer<M : Any> {
+    public fun serialize(model: M, output: Writeable, vararg options: Options.Write)
+    public fun deserialize(type: KClass<out M>, transientId: ReadMemory, input: ReadBuffer, vararg options: Options.Read): M
 }
 
-interface DefaultSerializer : Serializer<Any>, Options.Open
+public interface DefaultSerializer : Serializer<Any>, Options.Open

--- a/kdb/kodein-db-api/src/jvmMain/kotlin/org/kodein/db/TypeTableJvm.kt
+++ b/kdb/kodein-db-api/src/jvmMain/kotlin/org/kodein/db/TypeTableJvm.kt
@@ -5,7 +5,7 @@ import org.kodein.memory.io.KBuffer
 import org.kodein.memory.io.wrap
 import org.kodein.memory.text.toAsciiBytes
 
-fun TypeTable.Companion.withFullName(builder: TypeTable.Builder.() -> Unit = {}) = TypeTable(
+public fun TypeTable.Companion.withFullName(builder: TypeTable.Builder.() -> Unit = {}): TypeTable = TypeTable(
         { KBuffer.wrap(it.java.name.toAsciiBytes()) },
         { try { Class.forName(it.getAscii()).kotlin } catch (_: Throwable) { null } },
         builder

--- a/kdb/kodein-db-api/src/jvmMain/kotlin/org/kodein/db/model/annotations.kt
+++ b/kdb/kodein-db-api/src/jvmMain/kotlin/org/kodein/db/model/annotations.kt
@@ -4,12 +4,12 @@ import kotlin.reflect.KClass
 
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.FIELD, AnnotationTarget.PROPERTY_GETTER)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Id
+public annotation class Id
 
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.FIELD, AnnotationTarget.PROPERTY_GETTER)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Indexed(val name: String)
+public annotation class Indexed(val name: String)
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class PolymorphicCollection(val root: KClass<*>)
+public annotation class PolymorphicCollection(val root: KClass<*>)

--- a/kdb/kodein-db-api/src/jvmMain/kotlin/org/kodein/db/simpleNameOf.kt
+++ b/kdb/kodein-db-api/src/jvmMain/kotlin/org/kodein/db/simpleNameOf.kt
@@ -2,4 +2,4 @@ package org.kodein.db
 
 import kotlin.reflect.KClass
 
-actual fun simpleTypeNameOf(type: KClass<*>): String = type.java.simpleName
+public actual fun simpleTypeNameOf(type: KClass<*>): String = type.java.simpleName

--- a/kdb/kodein-db/build.gradle.kts
+++ b/kdb/kodein-db/build.gradle.kts
@@ -27,47 +27,30 @@ kodein {
             main.dependencies {
                 api(project(":kdb:kodein-db-api"))
                 api(project(":ldb:kodein-leveldb"))
-                implementation("org.jetbrains.kotlinx:atomicfu-common:$kotlinxAtomicFuVer")
+                implementation("org.jetbrains.kotlinx:atomicfu:$kotlinxAtomicFuVer")
             }
 
             test.dependencies {
                 implementation(project(":test-utils"))
                 implementation(project(":kdb:serializer:kodein-db-serializer-kotlinx"))
-                compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-runtime-common:$kotlinxSerializationVer")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinxSerializationVer")
             }
         }
 
         add(kodeinTargets.jvm.jvm) {
-            main.dependencies {
-                implementation("org.jetbrains.kotlinx:atomicfu:$kotlinxAtomicFuVer")
-            }
-
             test.dependencies {
                 implementation(project(":kdb:serializer:kodein-db-serializer-kryo-jvm"))
                 implementation(project(":ldb:kodein-leveldb-jni"))
-                compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinxSerializationVer")
             }
         }
 
         add(kodeinTargets.jvm.android) {
-            main.dependencies {
-                implementation("org.jetbrains.kotlinx:atomicfu:$kotlinxAtomicFuVer")
-            }
-
             test.dependencies {
                 implementation(project(":kdb:serializer:kodein-db-serializer-kryo-jvm"))
-                compileOnly("org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinxSerializationVer")
             }
         }
 
-        add(kodeinTargets.native.allApple + kodeinTargets.native.allDesktop) {
-            main.dependencies {
-                implementation("org.jetbrains.kotlinx:atomicfu-native:$kotlinxAtomicFuVer")
-            }
-            test.dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:$kotlinxSerializationVer")
-            }
-        }
+        add(kodeinTargets.native.allDarwin + kodeinTargets.native.allDesktop)
     }
 }
 

--- a/kdb/kodein-db/build.gradle.kts
+++ b/kdb/kodein-db/build.gradle.kts
@@ -33,7 +33,7 @@ kodein {
             test.dependencies {
                 implementation(project(":test-utils"))
                 implementation(project(":kdb:serializer:kodein-db-serializer-kotlinx"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinxSerializationVer")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVer")
             }
         }
 

--- a/kdb/kodein-db/src/allJvmMain/kotlin/org/kodein/db/impl/model/AbstractModelDBJvm.kt
+++ b/kdb/kodein-db/src/allJvmMain/kotlin/org/kodein/db/impl/model/AbstractModelDBJvm.kt
@@ -6,7 +6,7 @@ import org.kodein.db.impl.model.jvm.AnnotationTypeTable
 import org.kodein.db.model.orm.MetadataExtractor
 import org.kodein.db.model.orm.DefaultSerializer
 
-abstract class AbstractModelDBJvm : AbstractModelDBFactory() {
+public abstract class AbstractModelDBJvm : AbstractModelDBFactory() {
 
     private fun getClass(name: String): Class<*>? =
             try { Class.forName(name) }

--- a/kdb/kodein-db/src/allJvmMain/kotlin/org/kodein/db/impl/model/jvm/AnnotationMetadataExtractor.kt
+++ b/kdb/kodein-db/src/allJvmMain/kotlin/org/kodein/db/impl/model/jvm/AnnotationMetadataExtractor.kt
@@ -10,7 +10,7 @@ import java.lang.reflect.Field
 import java.lang.reflect.Member
 import java.lang.reflect.Method
 
-class AnnotationMetadataExtractor : MetadataExtractor {
+public class AnnotationMetadataExtractor : MetadataExtractor {
 
     private sealed class ValueGetter {
 

--- a/kdb/kodein-db/src/allJvmMain/kotlin/org/kodein/db/impl/model/jvm/AnnotationTypeTable.kt
+++ b/kdb/kodein-db/src/allJvmMain/kotlin/org/kodein/db/impl/model/jvm/AnnotationTypeTable.kt
@@ -9,7 +9,7 @@ import org.kodein.memory.io.wrap
 import org.kodein.memory.text.toAsciiBytes
 import kotlin.reflect.KClass
 
-class AnnotationTypeTable : TypeTable {
+public class AnnotationTypeTable : TypeTable {
     private val rootCache = HashMap<KClass<*>, KClass<*>>()
     private val nameCache = HashMap<ReadMemory, KClass<*>>()
 

--- a/kdb/kodein-db/src/allJvmMain/kotlin/org/kodein/db/impl/utils/LockJvm.kt
+++ b/kdb/kodein-db/src/allJvmMain/kotlin/org/kodein/db/impl/utils/LockJvm.kt
@@ -5,7 +5,7 @@ import kotlin.concurrent.withLock as ktWithLock
 import kotlin.concurrent.write as ktWrite
 
 
-actual typealias Lock = java.util.concurrent.locks.ReentrantLock
+public actual typealias Lock = java.util.concurrent.locks.ReentrantLock
 
 internal actual fun newLock(): Lock = Lock()
 
@@ -13,7 +13,7 @@ internal actual inline fun <T> Lock.withLock(action: () -> T): T = ktWithLock(ac
 
 
 
-actual typealias RWLock = java.util.concurrent.locks.ReentrantReadWriteLock
+public actual typealias RWLock = java.util.concurrent.locks.ReentrantReadWriteLock
 
 internal actual fun newRWLock(): RWLock = RWLock()
 

--- a/kdb/kodein-db/src/allJvmMain/kotlin/org/kodein/db/impl/utils/reflectJvm.kt
+++ b/kdb/kodein-db/src/allJvmMain/kotlin/org/kodein/db/impl/utils/reflectJvm.kt
@@ -2,4 +2,4 @@ package org.kodein.db.impl.utils
 
 import kotlin.reflect.KClass
 
-actual fun KClass<*>.kIsInstance(value: Any?) = java.isInstance(value)
+public actual fun KClass<*>.kIsInstance(value: Any?): Boolean = java.isInstance(value)

--- a/kdb/kodein-db/src/allNativeMain/kotlin/org/kodein/db/impl/DBNative.kt
+++ b/kdb/kodein-db/src/allNativeMain/kotlin/org/kodein/db/impl/DBNative.kt
@@ -6,11 +6,11 @@ import org.kodein.db.impl.model.ModelDBNative
 import org.kodein.db.model.ModelDB
 
 
-object DBNative : AbstractDBFactory() {
+public object DBNative : AbstractDBFactory() {
 
     override fun mdbFactory(): DBFactory<ModelDB> = ModelDBNative
 
 }
 
 @Suppress("unused")
-actual val DB.Companion.factory: DBFactory<DB> get() = DBNative
+public actual val DB.Companion.factory: DBFactory<DB> get() = DBNative

--- a/kdb/kodein-db/src/allNativeMain/kotlin/org/kodein/db/impl/data/DataDBNative.kt
+++ b/kdb/kodein-db/src/allNativeMain/kotlin/org/kodein/db/impl/data/DataDBNative.kt
@@ -6,8 +6,8 @@ import org.kodein.db.leveldb.LevelDBFactory
 import org.kodein.db.leveldb.native.LevelDBNative
 
 
-object DataDBNative : AbstractDataDBFactory() {
+public object DataDBNative : AbstractDataDBFactory() {
     override val ldbFactory: LevelDBFactory get() = LevelDBNative
 }
 
-actual val DataDB.Companion.default: DBFactory<DataDB> get() = DataDBNative
+public actual val DataDB.Companion.default: DBFactory<DataDB> get() = DataDBNative

--- a/kdb/kodein-db/src/allNativeMain/kotlin/org/kodein/db/impl/model/ModelDBNative.kt
+++ b/kdb/kodein-db/src/allNativeMain/kotlin/org/kodein/db/impl/model/ModelDBNative.kt
@@ -8,7 +8,7 @@ import org.kodein.db.model.ModelDB
 import org.kodein.db.model.orm.MetadataExtractor
 import org.kodein.db.model.orm.DefaultSerializer
 
-object ModelDBNative : AbstractModelDBFactory() {
+public object ModelDBNative : AbstractModelDBFactory() {
 
     override val ddbFactory: DBFactory<DataDB> get() = DataDBNative
 
@@ -19,4 +19,4 @@ object ModelDBNative : AbstractModelDBFactory() {
     override fun defaultTypeTable(): TypeTable? = null
 }
 
-actual val ModelDB.Companion.default: DBFactory<ModelDB> get() = ModelDBNative
+public actual val ModelDB.Companion.default: DBFactory<ModelDB> get() = ModelDBNative

--- a/kdb/kodein-db/src/allNativeMain/kotlin/org/kodein/db/impl/utils/kIsInstance.kt
+++ b/kdb/kodein-db/src/allNativeMain/kotlin/org/kodein/db/impl/utils/kIsInstance.kt
@@ -2,4 +2,4 @@ package org.kodein.db.impl.utils
 
 import kotlin.reflect.KClass
 
-actual fun KClass<*>.kIsInstance(value: Any?): Boolean = isInstance(value)
+public actual fun KClass<*>.kIsInstance(value: Any?): Boolean = isInstance(value)

--- a/kdb/kodein-db/src/allNativeMain/kotlin/org/kodein/db/impl/utils/lockNative.kt
+++ b/kdb/kodein-db/src/allNativeMain/kotlin/org/kodein/db/impl/utils/lockNative.kt
@@ -1,19 +1,19 @@
 package org.kodein.db.impl.utils
 
 
-class PhonyLock private constructor() {
-    companion object {
+public class PhonyLock private constructor() {
+    public companion object {
         internal val instance = PhonyLock()
     }
 }
 
-actual typealias Lock = PhonyLock
+public actual typealias Lock = PhonyLock
 
 internal actual fun newLock(): Lock = PhonyLock.instance
 
 internal actual inline fun <T> Lock.withLock(action: () -> T): T = action()
 
-actual typealias RWLock = PhonyLock
+public actual typealias RWLock = PhonyLock
 
 internal actual fun newRWLock(): Lock = PhonyLock.instance
 

--- a/kdb/kodein-db/src/androidMain/kotlin/org/kodein/db/impl/DBAndroid.kt
+++ b/kdb/kodein-db/src/androidMain/kotlin/org/kodein/db/impl/DBAndroid.kt
@@ -5,9 +5,9 @@ import org.kodein.db.DBFactory
 import org.kodein.db.impl.model.ModelDBAndroid
 import org.kodein.db.model.ModelDB
 
-object DBAndroid : AbstractDBFactory() {
+public object DBAndroid : AbstractDBFactory() {
     override fun mdbFactory(): DBFactory<ModelDB> = ModelDBAndroid
 }
 
 @Suppress("unused")
-actual val DB.Companion.factory: DBFactory<DB> get() = DBAndroid
+public actual val DB.Companion.factory: DBFactory<DB> get() = DBAndroid

--- a/kdb/kodein-db/src/androidMain/kotlin/org/kodein/db/impl/data/DataDBAndroid.kt
+++ b/kdb/kodein-db/src/androidMain/kotlin/org/kodein/db/impl/data/DataDBAndroid.kt
@@ -6,8 +6,8 @@ import org.kodein.db.leveldb.LevelDBFactory
 import org.kodein.db.leveldb.android.LevelDBAndroid
 
 
-object DataDBAndroid : AbstractDataDBFactory() {
+public object DataDBAndroid : AbstractDataDBFactory() {
     override val ldbFactory: LevelDBFactory get() = LevelDBAndroid
 }
 
-actual val DataDB.Companion.default: DBFactory<DataDB> get() = DataDBAndroid
+public actual val DataDB.Companion.default: DBFactory<DataDB> get() = DataDBAndroid

--- a/kdb/kodein-db/src/androidMain/kotlin/org/kodein/db/impl/model/ModelDBAndroid.kt
+++ b/kdb/kodein-db/src/androidMain/kotlin/org/kodein/db/impl/model/ModelDBAndroid.kt
@@ -5,10 +5,10 @@ import org.kodein.db.data.DataDB
 import org.kodein.db.impl.data.DataDBAndroid
 import org.kodein.db.model.ModelDB
 
-object ModelDBAndroid : AbstractModelDBJvm() {
+public object ModelDBAndroid : AbstractModelDBJvm() {
 
     override val ddbFactory: DBFactory<DataDB> get() = DataDBAndroid
 
 }
 
-actual val ModelDB.Companion.default: DBFactory<ModelDB> get() = ModelDBAndroid
+public actual val ModelDB.Companion.default: DBFactory<ModelDB> get() = ModelDBAndroid

--- a/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/AbstractDBFactory.kt
+++ b/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/AbstractDBFactory.kt
@@ -7,7 +7,7 @@ import org.kodein.db.impl.model.cache.middleware
 import org.kodein.db.model.ModelDB
 import org.kodein.db.model.cache.ModelCache
 
-abstract class AbstractDBFactory : DBFactory<DB> {
+public abstract class AbstractDBFactory : DBFactory<DB> {
 
    internal abstract fun mdbFactory(): DBFactory<ModelDB>
 

--- a/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/BatchImpl.kt
+++ b/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/BatchImpl.kt
@@ -7,7 +7,7 @@ import org.kodein.db.model.ModelBatch
 import org.kodein.memory.Closeable
 import org.kodein.memory.util.MaybeThrowable
 
-class BatchImpl(override val mdb: ModelBatch) : Batch, DBWriteModule, KeyMaker by mdb, Closeable by mdb {
+public class BatchImpl(override val mdb: ModelBatch) : Batch, DBWriteModule, KeyMaker by mdb, Closeable by mdb {
     private val batchOptions = ArrayList<Options.Write>()
 
     override fun write(vararg options: Options.Write) {

--- a/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/data/AbstractDataDBFactory.kt
+++ b/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/data/AbstractDataDBFactory.kt
@@ -8,7 +8,7 @@ import org.kodein.db.data.DataDB
 import org.kodein.db.ldb.LevelDBOptions
 import org.kodein.db.leveldb.LevelDBFactory
 
-abstract class AbstractDataDBFactory : DBFactory<DataDB> {
+public abstract class AbstractDataDBFactory : DBFactory<DataDB> {
 
     protected abstract val ldbFactory: LevelDBFactory
 

--- a/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/data/default.kt
+++ b/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/data/default.kt
@@ -3,4 +3,4 @@ package org.kodein.db.impl.data
 import org.kodein.db.DBFactory
 import org.kodein.db.data.DataDB
 
-expect val DataDB.Companion.default: DBFactory<DataDB>
+public expect val DataDB.Companion.default: DBFactory<DataDB>

--- a/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/default.kt
+++ b/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/default.kt
@@ -2,10 +2,10 @@ package org.kodein.db.impl
 
 import org.kodein.db.*
 
-expect val DB.Companion.factory: DBFactory<DB>
+public expect val DB.Companion.factory: DBFactory<DB>
 
-fun DB.Companion.open(path: String, vararg options: Options.Open): DB = DB.factory.open(path, *options)
-fun DB.Companion.destroy(path: String, vararg options: Options.Open) = DB.factory.destroy(path, *options)
+public fun DB.Companion.open(path: String, vararg options: Options.Open): DB = DB.factory.open(path, *options)
+public fun DB.Companion.destroy(path: String, vararg options: Options.Open): Unit = DB.factory.destroy(path, *options)
 
-fun DB.Companion.prefixed(prefix: String): DBFactory.Based<DB> = DB.factory.prefixed(prefix)
-fun DB.Companion.inDir(path: String): DBFactory.Based<DB> = DB.factory.inDir(path)
+public fun DB.Companion.prefixed(prefix: String): DBFactory.Based<DB> = DB.factory.prefixed(prefix)
+public fun DB.Companion.inDir(path: String): DBFactory.Based<DB> = DB.factory.inDir(path)

--- a/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/model/AbstractModelDBFactory.kt
+++ b/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/model/AbstractModelDBFactory.kt
@@ -7,7 +7,7 @@ import org.kodein.db.model.orm.MetadataExtractor
 import org.kodein.db.model.orm.NoMetadataExtractor
 import org.kodein.db.model.orm.DefaultSerializer
 
-abstract class AbstractModelDBFactory : DBFactory<ModelDB> {
+public abstract class AbstractModelDBFactory : DBFactory<ModelDB> {
 
     protected abstract val ddbFactory: DBFactory<DataDB>
 

--- a/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/model/ResettableCursorModule.kt
+++ b/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/model/ResettableCursorModule.kt
@@ -3,12 +3,12 @@ package org.kodein.db.impl.model
 import org.kodein.db.BaseCursor
 import org.kodein.memory.io.ReadMemory
 
-interface ResettableCursorModule : BaseCursor {
-    val cursor: BaseCursor
+public interface ResettableCursorModule : BaseCursor {
+    public val cursor: BaseCursor
 
-    fun reset()
+    public fun reset()
 
-    override fun isValid() = cursor.isValid()
+    override fun isValid(): Boolean = cursor.isValid()
 
     override fun next() {
         reset()
@@ -35,5 +35,5 @@ interface ResettableCursorModule : BaseCursor {
         cursor.seekTo(target)
     }
 
-    override fun transientSeekKey() = cursor.transientSeekKey()
+    override fun transientSeekKey(): ReadMemory = cursor.transientSeekKey()
 }

--- a/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/model/cache/ModelCache.kt
+++ b/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/model/cache/ModelCache.kt
@@ -6,5 +6,5 @@ import org.kodein.db.model.cache.ModelCache
 internal expect val defaultCacheSize: Long
 internal fun defaultCacheCopyMaxSize() = defaultCacheSize / 4
 
-fun ModelCache.Companion.middleware(maxSize: Long = defaultCacheSize, copyMaxSize: Long = defaultCacheCopyMaxSize()): (ModelDB) -> ModelDB =
+public fun ModelCache.Companion.middleware(maxSize: Long = defaultCacheSize, copyMaxSize: Long = defaultCacheCopyMaxSize()): (ModelDB) -> ModelDB =
         { CachedModelDB(it, ModelCacheImpl(maxSize), copyMaxSize) }

--- a/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/model/default.kt
+++ b/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/model/default.kt
@@ -3,4 +3,4 @@ package org.kodein.db.impl.model
 import org.kodein.db.DBFactory
 import org.kodein.db.model.ModelDB
 
-expect val ModelDB.Companion.default: DBFactory<ModelDB>
+public expect val ModelDB.Companion.default: DBFactory<ModelDB>

--- a/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/model/modelKeys.kt
+++ b/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/model/modelKeys.kt
@@ -10,7 +10,7 @@ internal val nextTypeKey = KBuffer.wrap(byteArrayOf(Prefix.TYPE, 'I'.toByte()))
 
 internal fun getTypeNameKeySize(typeName: ReadMemory) = 2 + typeName.size
 
-const val typeIdKeySize = 2 + 4
+public const val typeIdKeySize: Int = 2 + 4
 
 internal fun Writeable.putTypeNameKey(typeName: ReadMemory) {
     putByte(Prefix.TYPE)

--- a/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/utils/lock.kt
+++ b/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/utils/lock.kt
@@ -1,12 +1,12 @@
 package org.kodein.db.impl.utils
 
-expect class Lock
+public expect class Lock
 internal expect fun newLock(): Lock
 
 internal expect inline fun <T> Lock.withLock(action: () -> T): T
 
 
-expect class RWLock
+public expect class RWLock
 internal expect fun newRWLock(): RWLock
 
 internal expect inline fun <T> RWLock.write(action: () -> T): T

--- a/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/utils/reflect.kt
+++ b/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/utils/reflect.kt
@@ -2,4 +2,4 @@ package org.kodein.db.impl.utils
 
 import kotlin.reflect.KClass
 
-expect fun KClass<*>.kIsInstance(value: Any?): Boolean
+public expect fun KClass<*>.kIsInstance(value: Any?): Boolean

--- a/kdb/kodein-db/src/commonTest/kotlin/org/kodein/db/impl/model/models.kt
+++ b/kdb/kodein-db/src/commonTest/kotlin/org/kodein/db/impl/model/models.kt
@@ -1,6 +1,6 @@
 package org.kodein.db.impl.model
 
-import kotlinx.serialization.ContextualSerialization
+import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import org.kodein.db.*
 import org.kodein.db.model.ModelDB
@@ -43,7 +43,7 @@ data class City(val name: String, val location: Location, val postalCode: Int) :
 }
 
 @Serializable
-data class Message(@ContextualSerialization override val id: UUID, val from: Key<Person>, val message: String) : Metadata
+data class Message(@Contextual override val id: UUID, val from: Key<Person>, val message: String) : Metadata
 
 @Serializable
 data class Birth(val adult: Key<Adult>, val city: Key<City>) : HasMetadata {

--- a/kdb/kodein-db/src/jvmMain/kotlin/org/kodein/db/impl/DBJvm.kt
+++ b/kdb/kodein-db/src/jvmMain/kotlin/org/kodein/db/impl/DBJvm.kt
@@ -5,9 +5,9 @@ import org.kodein.db.DBFactory
 import org.kodein.db.impl.model.ModelDBJvm
 import org.kodein.db.model.ModelDB
 
-object DBJvm : AbstractDBFactory() {
+public object DBJvm : AbstractDBFactory() {
     override fun mdbFactory(): DBFactory<ModelDB> = ModelDBJvm
 }
 
 @Suppress("unused")
-actual val DB.Companion.factory: DBFactory<DB> get() = DBJvm
+public actual val DB.Companion.factory: DBFactory<DB> get() = DBJvm

--- a/kdb/kodein-db/src/jvmMain/kotlin/org/kodein/db/impl/data/DataDBJvm.kt
+++ b/kdb/kodein-db/src/jvmMain/kotlin/org/kodein/db/impl/data/DataDBJvm.kt
@@ -6,8 +6,8 @@ import org.kodein.db.leveldb.LevelDBFactory
 import org.kodein.db.leveldb.jvm.LevelDBJvm
 
 
-object DataDBJvm : AbstractDataDBFactory() {
+public object DataDBJvm : AbstractDataDBFactory() {
     override val ldbFactory: LevelDBFactory get() = LevelDBJvm
 }
 
-actual val DataDB.Companion.default: DBFactory<DataDB> get() = DataDBJvm
+public actual val DataDB.Companion.default: DBFactory<DataDB> get() = DataDBJvm

--- a/kdb/kodein-db/src/jvmMain/kotlin/org/kodein/db/impl/model/ModelDBJvm.kt
+++ b/kdb/kodein-db/src/jvmMain/kotlin/org/kodein/db/impl/model/ModelDBJvm.kt
@@ -5,10 +5,10 @@ import org.kodein.db.data.DataDB
 import org.kodein.db.impl.data.DataDBJvm
 import org.kodein.db.model.ModelDB
 
-object ModelDBJvm : AbstractModelDBJvm() {
+public object ModelDBJvm : AbstractModelDBJvm() {
 
     override val ddbFactory: DBFactory<DataDB> get() = DataDBJvm
 
 }
 
-actual val ModelDB.Companion.default: DBFactory<ModelDB> get() = ModelDBJvm
+public actual val ModelDB.Companion.default: DBFactory<ModelDB> get() = ModelDBJvm

--- a/kdb/serializer/kodein-db-serializer-kotlinx/build.gradle.kts
+++ b/kdb/serializer/kodein-db-serializer-kotlinx/build.gradle.kts
@@ -10,7 +10,7 @@ kodein {
 
         common.main.dependencies {
             api(project(":kdb:kodein-db-api"))
-            api("org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinxSerializationVer")
+            api("org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxSerializationVer")
             implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:$kotlinxSerializationVer")
         }
 

--- a/kdb/serializer/kodein-db-serializer-kotlinx/build.gradle.kts
+++ b/kdb/serializer/kodein-db-serializer-kotlinx/build.gradle.kts
@@ -10,24 +10,12 @@ kodein {
 
         common.main.dependencies {
             api(project(":kdb:kodein-db-api"))
-            api("org.jetbrains.kotlinx:kotlinx-serialization-runtime-common:$kotlinxSerializationVer")
-            implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor-common:$kotlinxSerializationVer")
+            api("org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinxSerializationVer")
+            implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:$kotlinxSerializationVer")
         }
 
-        add(kodeinTargets.jvm.jvm) {
-            main.dependencies {
-                api("org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlinxSerializationVer")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:$kotlinxSerializationVer")
-            }
-        }
-
-        add(kodeinTargets.native.allApple + kodeinTargets.native.allDesktop) {
-            main.dependencies {
-                api("org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:$kotlinxSerializationVer")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor-native:$kotlinxSerializationVer")
-            }
-        }
-
+        add(kodeinTargets.jvm.jvm)
+        add(kodeinTargets.native.allDarwin + kodeinTargets.native.allDesktop)
     }
 }
 

--- a/kdb/serializer/kodein-db-serializer-kotlinx/src/commonMain/kotlin/org/kodein/db/orm/kotlinx/KotlinxSerializer.kt
+++ b/kdb/serializer/kodein-db-serializer-kotlinx/src/commonMain/kotlin/org/kodein/db/orm/kotlinx/KotlinxSerializer.kt
@@ -16,7 +16,7 @@ import kotlin.collections.set
 import kotlin.jvm.JvmOverloads
 import kotlin.reflect.KClass
 
-object UUIDSerializer : KSerializer<UUID> {
+public object UUIDSerializer : KSerializer<UUID> {
     override val descriptor: SerialDescriptor = PrimitiveDescriptor("UUID", PrimitiveKind.STRING)
 
     override fun serialize(encoder: Encoder, value: UUID) {
@@ -32,15 +32,15 @@ object UUIDSerializer : KSerializer<UUID> {
 
 }
 
-class KotlinxSerializer @JvmOverloads constructor(block: Builder.() -> Unit = {}) : DefaultSerializer {
+public class KotlinxSerializer @JvmOverloads constructor(block: Builder.() -> Unit = {}) : DefaultSerializer {
     private val serializers = HashMap<KClass<*>, KSerializer<*>>()
 
     private val cbor = Cbor(updateMode = UpdateMode.UPDATE, context = serializersModule(UUIDSerializer))
 
-    inner class Builder {
-        fun <T : Any> register(type: KClass<T>, serializer: KSerializer<T>) { serializers[type] = serializer }
+    public inner class Builder {
+        public fun <T : Any> register(type: KClass<T>, serializer: KSerializer<T>) { serializers[type] = serializer }
 
-        inline operator fun <reified T : Any> KSerializer<T>.unaryPlus() {
+        public inline operator fun <reified T : Any> KSerializer<T>.unaryPlus() {
             register(T::class, this)
         }
     }

--- a/kdb/serializer/kodein-db-serializer-kryo-jvm/src/main/kotlin/org/kodein/db/orm/kryo/KryoSerializer.kt
+++ b/kdb/serializer/kodein-db-serializer-kryo-jvm/src/main/kotlin/org/kodein/db/orm/kryo/KryoSerializer.kt
@@ -14,7 +14,7 @@ import kotlin.reflect.KClass
 
 
 @Suppress("unused", "MemberVisibilityCanBePrivate")
-class KryoSerializer @JvmOverloads constructor(val kryo: Kryo = createKryo()) : DefaultSerializer {
+public class KryoSerializer @JvmOverloads public constructor(public val kryo: Kryo = createKryo()) : DefaultSerializer {
 
     override fun serialize(model: Any, output: Writeable, vararg options: Options.Write) {
         Output(output.asOuputStream()).use {
@@ -28,12 +28,12 @@ class KryoSerializer @JvmOverloads constructor(val kryo: Kryo = createKryo()) : 
         }
     }
 
-    companion object {
-        fun createKryo(
+    public companion object {
+        public fun createKryo(
                 typeTable: TypeTable? = null,
                 allowStructureUpdate: Boolean = true,
                 allowDeserializationWithoutConstructor: Boolean = true
-        ) = Kryo().apply {
+        ): Kryo = Kryo().apply {
             val registered = typeTable?.getRegisteredClasses()
             if (registered != null && registered.isNotEmpty()) {
                 registered.forEach { register(it.java) }

--- a/ldb/kodein-leveldb-api/build.gradle.kts
+++ b/ldb/kodein-leveldb-api/build.gradle.kts
@@ -17,7 +17,7 @@ kodein {
             target.setCompileClasspath()
         }
 
-        add(kodeinTargets.native.allApple + kodeinTargets.native.allDesktop)
+        add(kodeinTargets.native.allDarwin + kodeinTargets.native.allDesktop)
     }
 }
 

--- a/ldb/kodein-leveldb-api/src/allNativeMain/kotlin/org/kodein/db/leveldb/platform-actual.kt
+++ b/ldb/kodein-leveldb-api/src/allNativeMain/kotlin/org/kodein/db/leveldb/platform-actual.kt
@@ -1,16 +1,16 @@
 package org.kodein.db.leveldb
 
 
-actual class StackTrace(private val elements: Array<String>) {
+public actual class StackTrace(private val elements: Array<String>) {
 
-    actual fun write(on: Appendable) {
+    public actual fun write(on: Appendable) {
         on.append(elements.joinToString("\n"))
     }
 
-    actual companion object {
-        actual fun current() = StackTrace(Exception().getStackTrace())
+    public actual companion object {
+        public actual fun current(): StackTrace = StackTrace(Exception().getStackTrace())
     }
 
 }
 
-actual fun <T> newWeakHashSet(): MutableSet<T> = HashSet()
+public actual fun <T> newWeakHashSet(): MutableSet<T> = HashSet()

--- a/ldb/kodein-leveldb-api/src/commonMain/kotlin/org/kodein/db/leveldb/LevelDB.kt
+++ b/ldb/kodein-leveldb-api/src/commonMain/kotlin/org/kodein/db/leveldb/LevelDB.kt
@@ -12,12 +12,12 @@ import org.kodein.memory.io.ReadMemory
  *
  * This interface allows the use of different implementations of LevelDB.
  */
-interface LevelDB : Closeable {
+public interface LevelDB : Closeable {
 
     /**
      * path of the DB.
      */
-    val path: String
+    public val path: String
 
     /**
      * Put an entry into the database.
@@ -26,7 +26,7 @@ interface LevelDB : Closeable {
      * @param value The value ov the entry to put.
      * @param options Options that control this write operation.
      */
-    fun put(key: ReadMemory, value: ReadMemory, options: WriteOptions = WriteOptions.DEFAULT)
+    public fun put(key: ReadMemory, value: ReadMemory, options: WriteOptions = WriteOptions.DEFAULT)
 
     /**
      * Delete an entry from the database.
@@ -34,7 +34,7 @@ interface LevelDB : Closeable {
      * @param key The key of the entry to delete.
      * @param options Options that control this write operation.
      */
-    fun delete(key: ReadMemory, options: WriteOptions = WriteOptions.DEFAULT)
+    public fun delete(key: ReadMemory, options: WriteOptions = WriteOptions.DEFAULT)
 
     /**
      * Write a batch atomically to the database.
@@ -48,7 +48,7 @@ interface LevelDB : Closeable {
      * @param batch The batch to write.
      * @param options Options that control this write operation.
      */
-    fun write(batch: WriteBatch, options: WriteOptions = WriteOptions.DEFAULT)
+    public fun write(batch: WriteBatch, options: WriteOptions = WriteOptions.DEFAULT)
 
     /**
      * Get an entry value bytes from the database from its key.
@@ -59,7 +59,7 @@ interface LevelDB : Closeable {
      * @param options Options that control this read operation.
      * @return The entry value.
      */
-    fun get(key: ReadMemory, options: ReadOptions = ReadOptions.DEFAULT): Allocation?
+    public fun get(key: ReadMemory, options: ReadOptions = ReadOptions.DEFAULT): Allocation?
 
     /**
      * Get an entry value bytes by following the value of the given key.
@@ -78,7 +78,7 @@ interface LevelDB : Closeable {
      * @param options Options that control this read operation.
      * @return The found entry value
      */
-    fun indirectGet(key: ReadMemory, options: ReadOptions = ReadOptions.DEFAULT): Allocation?
+    public fun indirectGet(key: ReadMemory, options: ReadOptions = ReadOptions.DEFAULT): Allocation?
 
     /**
      * Get an entry value bytes by following the value of the cursor current key.
@@ -95,7 +95,7 @@ interface LevelDB : Closeable {
      * @param options Options that control this read operation.
      * @return The found entry value
      */
-    fun indirectGet(cursor: Cursor, options: ReadOptions = ReadOptions.DEFAULT): Allocation?
+    public fun indirectGet(cursor: Cursor, options: ReadOptions = ReadOptions.DEFAULT): Allocation?
 
     /**
      * Creates a new Cursor.
@@ -109,7 +109,7 @@ interface LevelDB : Closeable {
      * @param options Options that control this Cursors read operations.
      * @return A new Cursor.
      */
-    fun newCursor(options: ReadOptions = ReadOptions.DEFAULT): Cursor
+    public fun newCursor(options: ReadOptions = ReadOptions.DEFAULT): Cursor
 
     /**
      * Creates a new Snapshot.
@@ -121,7 +121,7 @@ interface LevelDB : Closeable {
      * @see .Write
      * @return A new Snapshot.
      */
-    fun newSnapshot(): Snapshot
+    public fun newSnapshot(): Snapshot
 
     /**
      * Creates a new WriteBatch.
@@ -133,9 +133,9 @@ interface LevelDB : Closeable {
      * @see .Write
      * @return A new WriteBatch.
      */
-    fun newWriteBatch(): WriteBatch
+    public fun newWriteBatch(): WriteBatch
 
-    companion object
+    public companion object {}
 
     // TODO: Add these methods
 //    /**
@@ -174,7 +174,7 @@ interface LevelDB : Closeable {
      * @see .NewWriteBatch
      * @see .Write
      */
-    interface WriteBatch : Closeable {
+    public interface WriteBatch : Closeable {
 
         /**
          * Registers an entry to be put into the database.
@@ -182,21 +182,21 @@ interface LevelDB : Closeable {
          * @param key The key of the entry to put.
          * @param value The value ov the entry to put.
          */
-        fun put(key: ReadMemory, value: ReadMemory)
+        public fun put(key: ReadMemory, value: ReadMemory)
 
         /**
          * Registers a key whose entry is to be deleted from the database.
          *
          * @param key The key of the entry to delete.
          */
-        fun delete(key: ReadMemory)
+        public fun delete(key: ReadMemory)
 
         /**
          * Clear all updates buffered in this batch.
          */
-        fun clear()
+        public fun clear()
 
-        fun append(source: WriteBatch)
+        public fun append(source: WriteBatch)
 
         // TODO: Add these methods
 //        interface Handler {
@@ -217,27 +217,27 @@ interface LevelDB : Closeable {
      * @see .NewSnapshot
      * @see .Write
      */
-    interface Snapshot : Closeable
+    public interface Snapshot : Closeable
 
     /**
      * An Cursor to iterate over the entries of a database or a Snapshot.
      */
-    interface Cursor : Closeable {
+    public interface Cursor : Closeable {
 
         /**
          * @return Whether or not the cursor is in a valid state.
          */
-        fun isValid(): Boolean
+        public fun isValid(): Boolean
 
         /**
          * Position the cursor on the first entry of the database.
          */
-        fun seekToFirst()
+        public fun seekToFirst()
 
         /**
          * Position the cursor on the last entry of the database.
          */
-        fun seekToLast()
+        public fun seekToLast()
 
         /**
          * Position the cursor to the entry corresponding to the provided key inside the database.
@@ -246,21 +246,21 @@ interface LevelDB : Closeable {
          *
          * @param target The key to seek to.
          */
-        fun seekTo(target: ReadMemory)
+        public fun seekTo(target: ReadMemory)
 
         /**
          * Position the cursor on the entry right next after the current one.
          *
          * Note that if this cursor was created without a Snapshot, it can be positionned on an entry that were inserted after the creation of the cursor.
          */
-        fun next()
+        public fun next()
 
         /**
          * Position the cursor on the entry right before the current one.
          *
          * Note that if this cursor was created without a Snapshot, it can be positionned on an entry that were inserted after the creation of the cursor.
          */
-        fun prev()
+        public fun prev()
 
         /**
          * Get a Buffer containing the current key.
@@ -269,7 +269,7 @@ interface LevelDB : Closeable {
          *
          * @return The key bytes.
          */
-        fun transientKey(): ReadBuffer
+        public fun transientKey(): ReadBuffer
 
         /**
          * Get a Buffer containing the current value.
@@ -278,7 +278,7 @@ interface LevelDB : Closeable {
          *
          * @return The value bytes.
          */
-        fun transientValue(): ReadBuffer
+        public fun transientValue(): ReadBuffer
 
         override fun close()
     }
@@ -286,7 +286,7 @@ interface LevelDB : Closeable {
     /**
      * Defines how to react if the database exists or not.
      */
-    enum class OpenPolicy(val createIfMissing: Boolean, val errorIfExists: Boolean) {
+    public enum class OpenPolicy(public val createIfMissing: Boolean, public val errorIfExists: Boolean) {
         /**
          * Open the database if it exists, fail otherwise.
          */
@@ -306,7 +306,7 @@ interface LevelDB : Closeable {
     /**
      * Options to control the behavior of a database.
      */
-    data class Options
+    public data class Options
     (
             /**
              * Defines how to react if the database exists or not.
@@ -449,15 +449,15 @@ interface LevelDB : Closeable {
 
 //            val comparator: ???
     ) {
-        companion object {
-            val DEFAULT = Options()
+        public companion object {
+            public val DEFAULT: Options = Options()
         }
     }
 
     /**
      * Options that control read operations.
      */
-    data class ReadOptions(
+    public data class ReadOptions(
             /**
              * If true, all data read from underlying storage will be verified against corresponding checksums.
              *
@@ -479,15 +479,15 @@ interface LevelDB : Closeable {
              */
             val snapshot: Snapshot? = null
     ) {
-        companion object {
-            val DEFAULT = ReadOptions()
+        public companion object {
+            public val DEFAULT: ReadOptions = ReadOptions()
         }
     }
 
     /**
      * Options that control write operations.
      */
-    data class WriteOptions(
+    public data class WriteOptions(
             /**
              * If true, the write will be flushed from the operating system buffer cache (by calling WritableFile::Sync()) before the write is considered complete.
              *
@@ -503,8 +503,8 @@ interface LevelDB : Closeable {
              */
             val sync: Boolean = false
     ) {
-        companion object {
-            val DEFAULT = WriteOptions()
+        public companion object {
+            public val DEFAULT: WriteOptions = WriteOptions()
         }
     }
 

--- a/ldb/kodein-leveldb-api/src/commonMain/kotlin/org/kodein/db/leveldb/LevelDBException.kt
+++ b/ldb/kodein-leveldb-api/src/commonMain/kotlin/org/kodein/db/leveldb/LevelDBException.kt
@@ -3,6 +3,6 @@ package org.kodein.db.leveldb
 /**
  * Exception thrown if something went wrong in a LevelDB operation.
  */
-class LevelDBException(message: String) : Exception(message) {
+public class LevelDBException(message: String) : Exception(message) {
     //    constructor(e: Throwable) : super(e)
 }

--- a/ldb/kodein-leveldb-api/src/commonMain/kotlin/org/kodein/db/leveldb/LevelDBFactory.kt
+++ b/ldb/kodein-leveldb-api/src/commonMain/kotlin/org/kodein/db/leveldb/LevelDBFactory.kt
@@ -3,7 +3,7 @@ package org.kodein.db.leveldb
 /**
  * A Sober-LevelDB factory is responsible for opening or destroying LevelDB databases.
  */
-interface LevelDBFactory {
+public interface LevelDBFactory {
     /**
      * Open or create a LevelDB database.
      *
@@ -13,14 +13,14 @@ interface LevelDBFactory {
      * @param options The database options.
      * @return The LevelDB Java object.
      */
-    fun open(path: String, options: LevelDB.Options = LevelDB.Options.DEFAULT): LevelDB
+    public fun open(path: String, options: LevelDB.Options = LevelDB.Options.DEFAULT): LevelDB
 
     /**
      * Destroy a LevelDB database, if it exists.
      *
      * @param path The path to the database to destroy.
      */
-    fun destroy(path: String, options: LevelDB.Options = LevelDB.Options.DEFAULT)
+    public fun destroy(path: String, options: LevelDB.Options = LevelDB.Options.DEFAULT)
 
     // TODO: Add these methods
 //        fun dumpFile(??)
@@ -29,11 +29,11 @@ interface LevelDBFactory {
 //        fun openTable(file: String, size: Int = -1, options: Options = Options.DEFAULT): Table
 
 
-    class Based(private val baseWithSeparator: String, private val factory: LevelDBFactory) : LevelDBFactory {
-        override fun open(path: String, options: LevelDB.Options) = factory.open(baseWithSeparator + path, options)
-        override fun destroy(path: String, options: LevelDB.Options) = factory.destroy(baseWithSeparator + path, options)
+    public class Based(private val baseWithSeparator: String, private val factory: LevelDBFactory) : LevelDBFactory {
+        override fun open(path: String, options: LevelDB.Options): LevelDB = factory.open(baseWithSeparator + path, options)
+        override fun destroy(path: String, options: LevelDB.Options): Unit = factory.destroy(baseWithSeparator + path, options)
     }
 }
 
-fun LevelDBFactory.prefixed(prefix: String) = LevelDBFactory.Based(prefix, this)
-fun LevelDBFactory.inDir(dir: String) = LevelDBFactory.Based("$dir/", this)
+public fun LevelDBFactory.prefixed(prefix: String): LevelDBFactory.Based = LevelDBFactory.Based(prefix, this)
+public fun LevelDBFactory.inDir(dir: String): LevelDBFactory.Based = LevelDBFactory.Based("$dir/", this)

--- a/ldb/kodein-leveldb-api/src/commonMain/kotlin/org/kodein/db/leveldb/PlatformCloseable.kt
+++ b/ldb/kodein-leveldb-api/src/commonMain/kotlin/org/kodein/db/leveldb/PlatformCloseable.kt
@@ -1,10 +1,11 @@
 package org.kodein.db.leveldb
 
 import kotlinx.atomicfu.atomic
+import org.kodein.log.newLogger
 import org.kodein.memory.Closeable
 
 
-abstract class PlatformCloseable(private val name: String, private val handler: Handler?, val options: LevelDB.Options) : Closeable {
+public abstract class PlatformCloseable(private val name: String, private val handler: Handler?, public val options: LevelDB.Options) : Closeable {
 
     private val stackTrace = if (options.trackClosableAllocation) {
         StackTrace.current()
@@ -35,9 +36,9 @@ abstract class PlatformCloseable(private val name: String, private val handler: 
         doClose()
     }
 
-    fun checkIsOpen() = check(!closed.value) { "$name has been closed" }
+    public fun checkIsOpen(): Unit = check(!closed.value) { "$name has been closed" }
 
-    fun closeBad() {
+    public fun closeBad() {
         if (closed.getAndSet(true))
             return
 
@@ -64,19 +65,19 @@ abstract class PlatformCloseable(private val name: String, private val handler: 
             closeBad()
     }
 
-    class Handler : Closeable {
+    public class Handler : Closeable {
 
         private val closed = atomic(false)
 
         private val set = newWeakHashSet<PlatformCloseable>()
 
-        fun add(pc: PlatformCloseable) {
+        public fun add(pc: PlatformCloseable) {
             if (closed.value)
                 return
             set.add(pc)
         }
 
-        fun remove(pc: PlatformCloseable) {
+        public fun remove(pc: PlatformCloseable) {
             if (!closed.value)
                 set.remove(pc)
         }

--- a/ldb/kodein-leveldb-api/src/commonMain/kotlin/org/kodein/db/leveldb/platform-expect.kt
+++ b/ldb/kodein-leveldb-api/src/commonMain/kotlin/org/kodein/db/leveldb/platform-expect.kt
@@ -1,11 +1,11 @@
 package org.kodein.db.leveldb
 
 
-expect class StackTrace {
-    fun write(on: Appendable)
-    companion object {
-        fun current(): StackTrace
+public expect class StackTrace {
+    public fun write(on: Appendable)
+    public companion object {
+        public fun current(): StackTrace
     }
 }
 
-expect fun <T> newWeakHashSet(): MutableSet<T>
+public expect fun <T> newWeakHashSet(): MutableSet<T>

--- a/ldb/kodein-leveldb-api/src/jvmMain/kotlin/org/kodein/db/leveldb/platform-actual.kt
+++ b/ldb/kodein-leveldb-api/src/jvmMain/kotlin/org/kodein/db/leveldb/platform-actual.kt
@@ -2,16 +2,16 @@ package org.kodein.db.leveldb
 
 import java.util.*
 
-actual class StackTrace(private val elements: Array<StackTraceElement>) {
+public actual class StackTrace(private val elements: Array<StackTraceElement>) {
 
-    actual fun write(on: Appendable) {
+    public actual fun write(on: Appendable) {
         on.append(elements.joinToString("\n"))
     }
 
-    actual companion object {
-        actual fun current() = StackTrace(Thread.currentThread().stackTrace)
+    public actual companion object {
+        public actual fun current(): StackTrace = StackTrace(Thread.currentThread().stackTrace)
     }
 
 }
 
-actual fun <T> newWeakHashSet(): MutableSet<T> = Collections.newSetFromMap(WeakHashMap<T, Boolean>())
+public actual fun <T> newWeakHashSet(): MutableSet<T> = Collections.newSetFromMap(WeakHashMap<T, Boolean>())

--- a/ldb/kodein-leveldb-jni/src/linuxMain/kotlin/org/kodein/db/leveldb/jvm/LevelDBJvmLinuxLoader.kt
+++ b/ldb/kodein-leveldb-jni/src/linuxMain/kotlin/org/kodein/db/leveldb/jvm/LevelDBJvmLinuxLoader.kt
@@ -1,5 +1,5 @@
 package org.kodein.db.leveldb.jvm
 
-class LevelDBJvmLinuxLoader : AbstractLevelDBLoader("linux") {
+public class LevelDBJvmLinuxLoader : AbstractLevelDBLoader("linux") {
     override fun getLibFileName(version: String): String = "libkodein-leveldb-jni-linux-${version.replace('.', '_')}.so"
 }

--- a/ldb/kodein-leveldb-jni/src/macosMain/kotlin/org/kodein/db/leveldb/jvm/LevelDBJvmMacosLoader.kt
+++ b/ldb/kodein-leveldb-jni/src/macosMain/kotlin/org/kodein/db/leveldb/jvm/LevelDBJvmMacosLoader.kt
@@ -1,5 +1,5 @@
 package org.kodein.db.leveldb.jvm
 
-class LevelDBJvmMacosLoader : AbstractLevelDBLoader("macos") {
+public class LevelDBJvmMacosLoader : AbstractLevelDBLoader("macos") {
     override fun getLibFileName(version: String): String = "libkodein-leveldb-jni-macos-${version.replace('.', '_')}.dylib"
 }

--- a/ldb/kodein-leveldb-jni/src/windowsMain/kotlin/org/kodein/db/leveldb/jvm/LevelDBJvmWindowsLoader.kt
+++ b/ldb/kodein-leveldb-jni/src/windowsMain/kotlin/org/kodein/db/leveldb/jvm/LevelDBJvmWindowsLoader.kt
@@ -1,5 +1,5 @@
 package org.kodein.db.leveldb.jvm
 
-class LevelDBJvmWindowsLoader : AbstractLevelDBLoader("windows") {
+public class LevelDBJvmWindowsLoader : AbstractLevelDBLoader("windows") {
     override fun getLibFileName(version: String): String = "kodein-leveldb-jni-windows-${version.replace('.', '_')}.dll"
 }

--- a/ldb/kodein-leveldb/build.gradle.kts
+++ b/ldb/kodein-leveldb/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.android.build.gradle.tasks.factory.AndroidUnitTest
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-import org.kodein.internal.gradle.KodeinMPPExtension
+import org.kodein.internal.gradle.KodeinMppExtension
 
 plugins {
     id("org.kodein.library.mpp-with-android")
@@ -55,7 +55,7 @@ kodein {
             }
         }
 
-        fun KodeinMPPExtension.TargetBuilder<KotlinNativeTarget>.configureCInterop(compilation: String) {
+        fun KodeinMppExtension.TargetBuilder<KotlinNativeTarget>.configureCInterop(compilation: String) {
             mainCompilation.cinterops.create("libleveldb") {
                 packageName("org.kodein.db.libleveldb")
 

--- a/ldb/kodein-leveldb/src/allJvmMain/kotlin/org/kodein/db/leveldb/jni/LevelDBJNI.kt
+++ b/ldb/kodein-leveldb/src/allJvmMain/kotlin/org/kodein/db/leveldb/jni/LevelDBJNI.kt
@@ -14,14 +14,14 @@ import java.nio.ByteBuffer
  * However, it requires its native library to be loaded (loading depends on the platform).
  */
 @Suppress("FunctionName")
-class LevelDBJNI private constructor(ptr: Long, private val optionsPtr: Long, options: LevelDB.Options, override val path: String) : NativeBound(ptr, "DB", null, options), LevelDB {
+public class LevelDBJNI private constructor(ptr: Long, private val optionsPtr: Long, options: LevelDB.Options, override val path: String) : NativeBound(ptr, "DB", null, options), LevelDB {
 
     private val dbHandler = Handler()
 
     /**
      * LevelDB Factory that handles native LevelDB databases.
      */
-    object Factory : LevelDBFactory {
+    public object Factory : LevelDBFactory {
 
         override fun open(path: String, options: LevelDB.Options): LevelDB {
             val optionsPtr = newNativeOptions(options)
@@ -247,7 +247,7 @@ class LevelDBJNI private constructor(ptr: Long, private val optionsPtr: Long, op
         }
     }
 
-    companion object {
+    public companion object {
 
         private fun newNativeOptions(options: LevelDB.Options): Long {
             return Native.optionsNew(

--- a/ldb/kodein-leveldb/src/allJvmMain/kotlin/org/kodein/db/leveldb/jni/NativeBound.kt
+++ b/ldb/kodein-leveldb/src/allJvmMain/kotlin/org/kodein/db/leveldb/jni/NativeBound.kt
@@ -3,9 +3,9 @@ package org.kodein.db.leveldb.jni
 import org.kodein.db.leveldb.LevelDB
 import org.kodein.db.leveldb.PlatformCloseable
 
-abstract class NativeBound(private var ptr: Long, name: String, handler: Handler?, options: LevelDB.Options) : PlatformCloseable(name, handler, options) {
+public abstract class NativeBound(private var ptr: Long, name: String, handler: Handler?, options: LevelDB.Options) : PlatformCloseable(name, handler, options) {
 
-    val nonZeroPtr: Long get() {
+    public val nonZeroPtr: Long get() {
         checkIsOpen()
         return ptr
     }

--- a/ldb/kodein-leveldb/src/allNativeMain/kotlin/org/kodein/db/leveldb/defaultNative.kt
+++ b/ldb/kodein-leveldb/src/allNativeMain/kotlin/org/kodein/db/leveldb/defaultNative.kt
@@ -2,4 +2,4 @@ package org.kodein.db.leveldb
 
 import org.kodein.db.leveldb.native.LevelDBNative
 
-actual val LevelDB.Companion.default: LevelDBFactory get() = LevelDBNative
+public actual val LevelDB.Companion.default: LevelDBFactory get() = LevelDBNative

--- a/ldb/kodein-leveldb/src/allNativeMain/kotlin/org/kodein/db/leveldb/native/LevelDBNative.kt
+++ b/ldb/kodein-leveldb/src/allNativeMain/kotlin/org/kodein/db/leveldb/native/LevelDBNative.kt
@@ -29,7 +29,7 @@ private inline fun <T> ldbCall(crossinline block: MemScope.(CPointerVar<ByteVar>
     ret
 }
 
-class OptionsPtrs(val options: CPointer<leveldb_options_t>, val cache: CPointer<leveldb_cache_t>?, val filterPolicy: CPointer<leveldb_filterpolicy_t>?)
+public class OptionsPtrs(public val options: CPointer<leveldb_options_t>, public val cache: CPointer<leveldb_cache_t>?, public val filterPolicy: CPointer<leveldb_filterpolicy_t>?)
 
 private fun LevelDB.Options.allocOptionsPtr(): OptionsPtrs {
 
@@ -99,11 +99,11 @@ private inline fun LevelDB.WriteOptions.usePointer(block: (CPointer<leveldb_writ
 }
 
 
-class LevelDBNative private constructor(ptr: CPointer<leveldb_t>, options: LevelDB.Options, private val optionsPtrs: OptionsPtrs, override val path: String) : PointerBound<leveldb_t>(ptr, "DB", null, options), LevelDB {
+public class LevelDBNative private constructor(ptr: CPointer<leveldb_t>, options: LevelDB.Options, private val optionsPtrs: OptionsPtrs, override val path: String) : PointerBound<leveldb_t>(ptr, "DB", null, options), LevelDB {
 
     private val dbHandler = Handler()
 
-    companion object Factory : LevelDBFactory {
+    public companion object Factory : LevelDBFactory {
 
         override fun open(path: String, options: LevelDB.Options): LevelDB {
             val ptrs = options.allocOptionsPtr()

--- a/ldb/kodein-leveldb/src/allNativeMain/kotlin/org/kodein/db/leveldb/native/PointerBound.kt
+++ b/ldb/kodein-leveldb/src/allNativeMain/kotlin/org/kodein/db/leveldb/native/PointerBound.kt
@@ -5,9 +5,9 @@ import kotlinx.cinterop.CPointer
 import org.kodein.db.leveldb.LevelDB
 import org.kodein.db.leveldb.PlatformCloseable
 
-abstract class PointerBound<T : CPointed>(private var ptr: CPointer<T>?, name: String, handler: Handler?, options: LevelDB.Options) : PlatformCloseable(name, handler, options) {
+public abstract class PointerBound<T : CPointed>(private var ptr: CPointer<T>?, name: String, handler: Handler?, options: LevelDB.Options) : PlatformCloseable(name, handler, options) {
 
-    val nonNullPtr: CPointer<T> get() {
+    public val nonNullPtr: CPointer<T> get() {
         checkIsOpen()
         return ptr!!
     }

--- a/ldb/kodein-leveldb/src/allNativeMain/kotlin/org/kodein/db/leveldb/native/ReadBuffer.kt
+++ b/ldb/kodein-leveldb/src/allNativeMain/kotlin/org/kodein/db/leveldb/native/ReadBuffer.kt
@@ -6,7 +6,7 @@ import kotlinx.cinterop.plus
 import kotlinx.cinterop.refTo
 import org.kodein.memory.io.*
 
-fun ReadMemory.pointer(): CValuesRef<ByteVar> = when (val b = internalBuffer()) {
+public fun ReadMemory.pointer(): CValuesRef<ByteVar> = when (val b = internalBuffer()) {
     is CPointerKBuffer -> (b.pointer + b.absPosition)!!
     is ByteArrayKBuffer -> { b.array.refTo(b.absPosition) }
     else -> { b.getBytes(0).refTo(0) }

--- a/ldb/kodein-leveldb/src/androidMain/kotlin/org/kodein/db/leveldb/android/LevelDBAndroid.kt
+++ b/ldb/kodein-leveldb/src/androidMain/kotlin/org/kodein/db/leveldb/android/LevelDBAndroid.kt
@@ -4,7 +4,7 @@ import org.kodein.db.leveldb.LevelDBFactory
 import org.kodein.db.leveldb.jni.LevelDBJNI
 
 
-object LevelDBAndroid : LevelDBFactory by LevelDBJNI.Factory {
+public object LevelDBAndroid : LevelDBFactory by LevelDBJNI.Factory {
     init {
         System.loadLibrary("kodein-leveldb-jni")
     }

--- a/ldb/kodein-leveldb/src/androidMain/kotlin/org/kodein/db/leveldb/defaultAndroid.kt
+++ b/ldb/kodein-leveldb/src/androidMain/kotlin/org/kodein/db/leveldb/defaultAndroid.kt
@@ -2,4 +2,4 @@ package org.kodein.db.leveldb
 
 import org.kodein.db.leveldb.android.LevelDBAndroid
 
-actual val LevelDB.Companion.default: LevelDBFactory get() = LevelDBAndroid
+public actual val LevelDB.Companion.default: LevelDBFactory get() = LevelDBAndroid

--- a/ldb/kodein-leveldb/src/commonMain/kotlin/org/kodein/db/leveldb/default.kt
+++ b/ldb/kodein-leveldb/src/commonMain/kotlin/org/kodein/db/leveldb/default.kt
@@ -1,3 +1,3 @@
 package org.kodein.db.leveldb
 
-expect val LevelDB.Companion.default: LevelDBFactory
+public expect val LevelDB.Companion.default: LevelDBFactory

--- a/ldb/kodein-leveldb/src/jvmMain/kotlin/org/kodein/db/leveldb/defaultJvm.kt
+++ b/ldb/kodein-leveldb/src/jvmMain/kotlin/org/kodein/db/leveldb/defaultJvm.kt
@@ -2,4 +2,4 @@ package org.kodein.db.leveldb
 
 import org.kodein.db.leveldb.jvm.LevelDBJvm
 
-actual val LevelDB.Companion.default: LevelDBFactory get() = LevelDBJvm
+public actual val LevelDB.Companion.default: LevelDBFactory get() = LevelDBJvm

--- a/ldb/kodein-leveldb/src/jvmMain/kotlin/org/kodein/db/leveldb/jvm/AbstractLevelDBLoader.kt
+++ b/ldb/kodein-leveldb/src/jvmMain/kotlin/org/kodein/db/leveldb/jvm/AbstractLevelDBLoader.kt
@@ -9,11 +9,11 @@ import java.security.MessageDigest
 import java.util.*
 
 
-abstract class AbstractLevelDBLoader(val os: String) : LevelDBFactory by LevelDBJNI.Factory {
+public abstract class AbstractLevelDBLoader(public val os: String) : LevelDBFactory by LevelDBJNI.Factory {
 
-    abstract fun getLibFileName(version: String): String
+    public abstract fun getLibFileName(version: String): String
 
-    fun load() {
+    public fun load() {
         val resourcesProps = javaClass.getResourceAsStream("/kodein-leveldb-jni-$os.properties")
                 ?.use { Properties().apply { load(it) } }
                 ?: error("Could not load kodein-leveldb-jni-$os.properties")

--- a/ldb/kodein-leveldb/src/jvmMain/kotlin/org/kodein/db/leveldb/jvm/LevelDBJvm.kt
+++ b/ldb/kodein-leveldb/src/jvmMain/kotlin/org/kodein/db/leveldb/jvm/LevelDBJvm.kt
@@ -10,7 +10,7 @@ import java.security.MessageDigest
 import java.util.*
 
 
-object LevelDBJvm : LevelDBFactory by LevelDBJNI.Factory {
+public object LevelDBJvm : LevelDBFactory by LevelDBJNI.Factory {
     init {
         val os = System.getProperty("os.name").toLowerCase().let {
             when  {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
         maven(url = "https://dl.bintray.com/kodein-framework/kodein-dev")
     }
     dependencies {
-        classpath("org.kodein.internal.gradle:kodein-internal-gradle-settings:3.7.0-kotlin-1.4-rc-74")
+        classpath("org.kodein.internal.gradle:kodein-internal-gradle-settings:4.0.1")
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,9 +2,10 @@ buildscript {
     repositories {
         mavenLocal()
         maven(url = "https://dl.bintray.com/kodein-framework/Kodein-Internal-Gradle")
+        maven(url = "https://dl.bintray.com/kodein-framework/kodein-dev")
     }
     dependencies {
-        classpath("org.kodein.internal.gradle:kodein-internal-gradle-settings:3.4.5")
+        classpath("org.kodein.internal.gradle:kodein-internal-gradle-settings:3.7.0-kotlin-1.4-rc-74")
     }
 }
 

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -47,7 +47,7 @@ kodein {
             }
         }
 
-        add(kodeinTargets.native.allApple + kodeinTargets.native.allDesktop)
+        add(kodeinTargets.native.allDarwin + kodeinTargets.native.allDesktop)
 
         allTargets {
             mainCommonCompilation.kotlinOptions.freeCompilerArgs = listOf("-Xuse-experimental=kotlin.Experimental")

--- a/test-utils/src/commonMain/kotlin/org/kodein/db/test/utils/logCountFilter.kt
+++ b/test-utils/src/commonMain/kotlin/org/kodein/db/test/utils/logCountFilter.kt
@@ -1,14 +1,15 @@
 package org.kodein.db.test.utils
 
 import org.kodein.log.LogFrontend
+import org.kodein.log.LogReceiver
 import org.kodein.log.Logger
 import kotlin.reflect.KClass
 
 class AssertLogger {
     val entries = ArrayList<Triple<Logger.Tag, Logger.Entry, String?>>()
 
-    val frontEnd: LogFrontend = { c ->
-        { e, m ->
+    val frontEnd: LogFrontend = LogFrontend { c: Logger.Tag ->
+        LogReceiver { e: Logger.Entry, m: String? ->
             entries += Triple(c, e, m)
         }
     }

--- a/test-utils/src/commonMain/kotlin/org/kodein/db/test/utils/logCountFilter.kt
+++ b/test-utils/src/commonMain/kotlin/org/kodein/db/test/utils/logCountFilter.kt
@@ -5,7 +5,7 @@ import org.kodein.log.Logger
 import kotlin.reflect.KClass
 
 class AssertLogger {
-    val entries = ArrayList<Triple<KClass<*>, Logger.Entry, String?>>()
+    val entries = ArrayList<Triple<Logger.Tag, Logger.Entry, String?>>()
 
     val frontEnd: LogFrontend = { c ->
         { e, m ->


### PR DESCRIPTION
Mainly upgrade Kotlin to 1.4.0, with:
- explicit mode
- new versions for: 
    - kodein-log
    - kodein-memory
    - kotlinx-serialization
    - atomicfu
- New kotlinx-serialization API
- fun interface for Kodein Log usage
- CI changes

Need to improve `KotlinxSerializer` to remove the use of `InternalSerializationApi`