### PR TITLE
Improve docs (language and content)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ println(does.joinToString()) // Jane, John
 
 Contributions are very welcome and greatly appreciated! The great majority of pull requests are eventually merged.
 
-To contribute, simply fork [the project on Github](https://github.com/Kodein-Framework/Kodein-DB), fix whatever is iching you, and submit a pull request!
+To contribute, simply fork [the project on Github](https://github.com/Kodein-Framework/Kodein-DB), fix whatever is itching you, and submit a pull request!
 
-We are sure that this documentation contains typos, inaccuracies and languages error.
+We are sure that this documentation contains typos, inaccuracies and language mistakes.
 If you feel like enhancing this document, you can propose a pull request that modifies [the documentation documents](https://github.com/Kodein-Framework/Kodein-DB/tree/master/doc).
 (Documentation is auto-generated from those).

--- a/doc/modules/core/pages/defining-data-model.adoc
+++ b/doc/modules/core/pages/defining-data-model.adoc
@@ -32,7 +32,7 @@ When targeting *only the JVM*, you can simply use annotations:
 data class User(
     @Id val uid: String,
     val firstName: String,
-    @Index("lastName") val lastName: String
+    @Indexed("lastName") val lastName: String
 )
 ----
 
@@ -47,7 +47,7 @@ data class User(
     val firstName: String,
     val lastName: String
 ) {
-    @Index("name") fun nameIndex() = listOf(lastName, firstName)
+    @Indexed("name") fun nameIndex() = listOf(lastName, firstName)
 }
 ----
 

--- a/doc/modules/core/pages/defining-data-model.adoc
+++ b/doc/modules/core/pages/defining-data-model.adoc
@@ -24,7 +24,7 @@ A composite index allows you to:
 
 ==== With annotations
 
-When targeting *only the JVM*, you can simply use annotations:
+When targeting *only the JVM* (and not inheriting from `Metadata`), you can simply use annotations:
 
 [source,kotlin]
 .A simple model

--- a/doc/modules/core/pages/defining-data-model.adoc
+++ b/doc/modules/core/pages/defining-data-model.adoc
@@ -154,7 +154,7 @@ NOTE: A `Value` is a serializable entity where the serialized bytes define the o
 
 === Types usable as Value
 
-By default, the Kodein-DB understands the following types to be used as values: `ByteArray`, `ReadBuffer`, `Boolean`, `Short`, `Int`, `Long`, `Char`, `CharSequence` (such as `String`), Kodein-Memory `UUID` (*not* `java.util.UUID`, `Key`).
+By default, the Kodein-DB understands the following types to be used as values: `ByteArray`, `ReadBuffer`, `Boolean`, `Short`, `Int`, `Long`, `Char`, `CharSequence` (such as `String`), Kodein-Memory `UUID` (*not* `java.util.UUID`) and `Key`.
 
 [IMPORTANT]
 ====

--- a/doc/modules/core/pages/iteration.adoc
+++ b/doc/modules/core/pages/iteration.adoc
@@ -9,6 +9,8 @@ IMPORTANT: Cursors are `Closeable`! You need to either close them after use, or 
 
 You can iterate:
 
+=== Over all elements
+
 - Over all models of the database:
 +
 [source,kotlin]
@@ -23,12 +25,19 @@ CAUTION: When using `findAll()` on multiplatform projects, you *must* define a x
 ----
 val cursor = db.find<User>().all()
 ----
+
+=== By id
+
 - Over all models of a collection whose composite ID begins with a specific value, ordered by id:
 +
 [source,kotlin]
 ----
 val cursor = db.find<User>().byId("Doe")
 ----
+
+=== Over an index
+
+==== Specific index
 - Over all models of a collection, ordered by an index:
 +
 [source,kotlin]
@@ -41,12 +50,22 @@ val cursor = db.find<User>().byIndex("lastName")
 ----
 val cursor = db.find<User>().byIndex("lastName", "Doe")
 ----
+
+==== Composite index
 - Over all models of a collection with an index composite value starting with a given value, ordered by that index:
 +
 [source,kotlin]
 ----
 val cursor = db.find<User>().byIndex("name", "Doe")
 ----
+- Over all models of a collection with an index composite value exactly matching the given values, ordered by that index:
++
+[source,kotlin]
+----
+val cursor = db.find<User>().byIndex("name", "Doe", "John")
+----
+
+==== Using isOpen
 - Over all models of a collection with an index composite value starting with a given prefix, ordered by that index:
 +
 [source,kotlin]


### PR DESCRIPTION
- fixed spelling mistakes
- changed `@Index` to `@Indexed`
- clarification that the annotations do not work when inheriting from `Metadata`
- headings for the different ways of getting a cursor