### PR TITLE
Fix deleteById - use the type

### DIFF
--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Batch.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/Batch.kt
@@ -19,7 +19,7 @@ public interface Batch : DBWrite, Closeable {
 
 public inline fun <reified M : Any> Batch.delete(key: Key<M>, vararg options: Options.BatchDelete): Unit = delete(M::class, key, *options)
 
-public inline fun <reified M : Any> Batch.deleteById(vararg id: Any, options: Array<out Options.BatchDelete> = emptyArray()): Unit = delete(keyById(*id), *options)
+public inline fun <reified M : Any> Batch.deleteById(vararg id: Any, options: Array<out Options.BatchDelete> = emptyArray()): Unit = delete(keyById<M>(*id), *options)
 
 public inline fun <reified M : Any> Batch.deleteAll(cursor: Cursor<M>, vararg options: Options.BatchDelete) {
     cursor.useKeys { seq -> seq.forEach { delete(it, *options) } }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/DB.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/DB.kt
@@ -45,7 +45,7 @@ public interface DB : DBRead, DBWrite, Closeable {
 
 public inline fun <reified M : Any> DB.delete(key: Key<M>, vararg options: Options.DirectDelete): Unit = delete(M::class, key, *options)
 
-public inline fun <reified M : Any> DB.deleteById(vararg id: Any, options: Array<out Options.DirectDelete> = emptyArray()): Unit = delete(keyById(*id), *options)
+public inline fun <reified M : Any> DB.deleteById(vararg id: Any, options: Array<out Options.DirectDelete> = emptyArray()): Unit = delete(keyById<M>(*id), *options)
 
 public inline fun <reified M : Any> DB.deleteAll(cursor: Cursor<M>, vararg options: Options.DirectDelete) {
     cursor.useKeys { seq -> seq.forEach { delete(it, *options) } }

--- a/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/DBWrite.kt
+++ b/kdb/kodein-db-api/src/commonMain/kotlin/org/kodein/db/DBWrite.kt
@@ -17,7 +17,7 @@ public inline fun <reified M : Any> DBWrite.delete(key: Key<M>): Unit = delete(k
 public inline fun <reified M : Any> DBWrite.delete(key: Key<M>, vararg options: Options.Deletes): Unit = delete(M::class, key, *options)
 
 public inline fun <reified M : Any> DBWrite.deleteById(vararg id: Any): Unit = deleteById<M>(*id, options = emptyArray())
-public inline fun <reified M : Any> DBWrite.deleteById(vararg id: Any, options: Array<out Options.Deletes> = emptyArray()): Unit = delete(keyById(*id), *options)
+public inline fun <reified M : Any> DBWrite.deleteById(vararg id: Any, options: Array<out Options.Deletes> = emptyArray()): Unit = delete(keyById<M>(*id), *options)
 
 public inline fun <reified M : Any> DBWrite.deleteFrom(model: M): Unit = delete(keyFrom(model), options = emptyArray())
 public inline fun <reified M : Any> DBWrite.deleteFrom(model: M, vararg options: Options.Deletes): Unit =


### PR DESCRIPTION
`deleteById` previously did not work because the type was omitted when calling the `keyById` function, I simply added the type.