### PR TITLE
Fix #42 flowOf doesn't respect the passed key.

### DIFF
--- a/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/DBImpl.kt
+++ b/kdb/kodein-db/src/commonMain/kotlin/org/kodein/db/impl/DBImpl.kt
@@ -34,8 +34,8 @@ internal class DBImpl(override val mdb: ModelDB) : DB, DBReadModule, KeyMaker by
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun <M : Any> flowOf(type: KClass<M>, key: Key<M>, init: Boolean): Flow<M?> = callbackFlow {
         val subscription = on(type).register(object : DBListener<M> {
-            override fun didDelete(operation: Operation.Delete<M>) { trySend(null) }
-            override fun didPut(operation: Operation.Put<M>) { trySend(operation.model) }
+            override fun didDelete(operation: Operation.Delete<M>) { if (operation.key == key) trySend(null) }
+            override fun didPut(operation: Operation.Put<M>) { if (operation.key == key) trySend(operation.model) }
         })
         if (init) trySend(get(type, key))
         awaitClose { subscription.close() }

--- a/kdb/kodein-db/src/commonTest/kotlin/org/kodein/db/impl/DBTests_04_Flows.kt
+++ b/kdb/kodein-db/src/commonTest/kotlin/org/kodein/db/impl/DBTests_04_Flows.kt
@@ -46,10 +46,10 @@ abstract class DBTests_04_Flows : DBTests() {
 
             repeat(10) { yield() }
 
-            var salomon = Adult("BRYS", "Salomon", Date(15, 12, 1786))
+            var salomon = Adult("Salomon","BRYS", Date(15, 12, 1786))
             db.put(salomon)
 
-            expected = "Put:Adult(firstName=BRYS, lastName=Salomon, birth=Date(day=15, month=12, year=1786))"
+            expected = "Put:Adult(firstName=Salomon, lastName=BRYS, birth=Date(day=15, month=12, year=1786))"
             assertEquals(0, count)
             repeat(10) { yield() }
             assertEquals(1, count)
@@ -57,14 +57,14 @@ abstract class DBTests_04_Flows : DBTests() {
             salomon = salomon.copy(birth = salomon.birth.copy(year = 1986))
             db.put(salomon)
 
-            expected = "Put:Adult(firstName=BRYS, lastName=Salomon, birth=Date(day=15, month=12, year=1986))"
+            expected = "Put:Adult(firstName=Salomon, lastName=BRYS, birth=Date(day=15, month=12, year=1986))"
             assertEquals(1, count)
             repeat(10) { yield() }
             assertEquals(2, count)
 
             db.deleteFrom(salomon)
 
-            expected = "Delete:Adult(firstName=BRYS, lastName=Salomon, birth=Date(day=15, month=12, year=1986))"
+            expected = "Delete:Adult(firstName=Salomon, lastName=BRYS, birth=Date(day=15, month=12, year=1986))"
             assertEquals(2, count)
             repeat(10) { yield() }
             assertEquals(3, count)
@@ -74,7 +74,7 @@ abstract class DBTests_04_Flows : DBTests() {
     @Test
     fun test01_stateFlow() {
         runBlockingTest {
-            val flow = db.stateFlowOfId<Adult>(this, "Salomon", "BRYS")
+            val flow = db.stateFlowOfId<Adult>(this, "BRYS", "Salomon")
 
             var expected: Adult? = null
             var count = 0
@@ -89,7 +89,7 @@ abstract class DBTests_04_Flows : DBTests() {
             repeat(10) { yield() }
             assertEquals(1, count)
 
-            val salomon = Adult("BRYS", "Salomon", Date(15, 12, 1986))
+            val salomon = Adult("Salomon", "BRYS", Date(15, 12, 1986))
             db.put(salomon)
 
             expected = salomon
@@ -109,7 +109,7 @@ abstract class DBTests_04_Flows : DBTests() {
     @Test
     fun test02_flowOf() {
         runBlockingTest {
-            val flow = db.flowOf<Adult>(db.keyById("Salomon", "BRYS"))
+            val flow = db.flowOf<Adult>(db.keyById("BRYS", "Salomon"))
 
             var expected: Adult? = null
             var count = 0
@@ -124,7 +124,7 @@ abstract class DBTests_04_Flows : DBTests() {
             repeat(10) { yield() }
             assertEquals(1, count)
 
-            val salomon = Adult("BRYS", "Salomon", Date(15, 12, 1986))
+            val salomon = Adult("Salomon", "BRYS", Date(15, 12, 1986))
             db.put(salomon)
 
             expected = salomon
@@ -134,7 +134,7 @@ abstract class DBTests_04_Flows : DBTests() {
 
             // We put someone into the database who doesn't match the key given to flowOf and make sure there is no flow
             // emissions.
-            val imposter = Adult("BRYS", "Solomon", Date(15, 12, 1986))
+            val imposter = Adult("Solomon", "BRYS", Date(15, 12, 1986))
             db.put(imposter)
 
             assertEquals(2, count)

--- a/kdb/kodein-db/src/commonTest/kotlin/org/kodein/db/impl/DBTests_04_Flows.kt
+++ b/kdb/kodein-db/src/commonTest/kotlin/org/kodein/db/impl/DBTests_04_Flows.kt
@@ -7,6 +7,8 @@ import org.kodein.db.Operation
 import org.kodein.db.deleteFrom
 import org.kodein.db.impl.model.Adult
 import org.kodein.db.impl.model.Date
+import org.kodein.db.flowOf
+import org.kodein.db.keyById
 import org.kodein.db.on
 import org.kodein.db.stateFlowOfId
 import org.kodein.db.test.utils.runBlockingTest
@@ -72,7 +74,7 @@ abstract class DBTests_04_Flows : DBTests() {
     @Test
     fun test01_stateFlow() {
         runBlockingTest {
-            val flow = db.stateFlowOfId<Adult>(this, "BRYS", "Salomon")
+            val flow = db.stateFlowOfId<Adult>(this, "Salomon", "BRYS")
 
             var expected: Adult? = null
             var count = 0
@@ -99,6 +101,58 @@ abstract class DBTests_04_Flows : DBTests() {
 
             expected = null
             assertEquals(2, count)
+            repeat(10) { yield() }
+            assertEquals(3, count)
+        }
+    }
+
+    @Test
+    fun test02_flowOf() {
+        runBlockingTest {
+            val flow = db.flowOf<Adult>(db.keyById("Salomon", "BRYS"))
+
+            var expected: Adult? = null
+            var count = 0
+            launch {
+                flow.collect {
+                    ++count
+                    assertEquals(expected, it)
+                }
+            }
+
+            assertEquals(0, count)
+            repeat(10) { yield() }
+            assertEquals(1, count)
+
+            val salomon = Adult("BRYS", "Salomon", Date(15, 12, 1986))
+            db.put(salomon)
+
+            expected = salomon
+            assertEquals(1, count)
+            repeat(10) { yield() }
+            assertEquals(2, count)
+
+            // We put someone into the database who doesn't match the key given to flowOf and make sure there is no flow
+            // emissions.
+            val imposter = Adult("BRYS", "Solomon", Date(15, 12, 1986))
+            db.put(imposter)
+
+            assertEquals(2, count)
+            repeat(10) { yield() }
+            assertEquals(2, count)
+
+            // Deleting Salomon should emit because we are observing him.
+            db.deleteFrom(salomon)
+
+            expected = null
+            assertEquals(2, count)
+            repeat(10) { yield() }
+            assertEquals(3, count)
+
+            // Deleting the imposter shouldn't emit since we are only observing Salomon.
+            db.deleteFrom(imposter)
+
+            assertEquals(3, count)
             repeat(10) { yield() }
             assertEquals(3, count)
         }


### PR DESCRIPTION
**Summary**
This Pull Request fixes #42.

It also adds flowOf tests to DBTests_04_Flows.kt.

**Notes**
I noticed something strange when writing the tests.

For some reason `keyById` (and by extension the stateFlowOfId tests) require the id `varargs` to be passed as `keyById("Salomon", "BRYS")` instead of the way they are defined in the `Person` model, which is `override val id get() = listOf(lastName, firstName)`

I'm not sure if this is a bug. I think it's following the declaration order of the `data class`. I've changed the test for `stateFlow`, this issue was hidden before because the key wasn't being compared by the listener, but the keys being generated in the listener's `operation` were different from what was being generated for the parameters passed to `stateFlowOfId`.

I'm happy to write some docs for `flowOf` if you wish, but I noticed that the docs on master are ahead of the docs on the website, so these flows weren't as undocumented as I thought, infact they are quite well documented!